### PR TITLE
Disable recyclarr by default, I have realized the error of my ways

### DIFF
--- a/modules/recyclarr/default.nix
+++ b/modules/recyclarr/default.nix
@@ -32,8 +32,7 @@ in {
   options.nixflix.recyclarr = {
     enable = mkOption {
       type = types.bool;
-      default = nixflix.radarr.enable or nixflix.sonarr.enable or nixflix.sonarr-anime.enable;
-      defaultText = literalExpression "nixflix.radarr.enable or nixflix.sonarr.enable or nixflix.sonarr-anime.enable";
+      default = false;
       description = "Whether to enable Recyclarr for automated TRaSH guide syncing";
     };
 


### PR DESCRIPTION
I'm sorry for waffling on this. All of the other features are opt-in. This really shouldn't be any different.

What if someone doesn't want this feature. Changes will be made to their instances that they don't understand.
And they would just **have to know** that this feature is enabled by default. It is not a nice thing to do to users.

I'm also sorry to anyone who's instances I messed up by enabling this feature by default. I really hope I didn't mess up anyone's configuration.
