### PR TITLE
Fix not working jellyseerr auth after secure curl refactor

### DIFF
--- a/modules/jellyseerr/authUtil.nix
+++ b/modules/jellyseerr/authUtil.nix
@@ -81,7 +81,7 @@ in
               "Content-Type" = "application/json";
             };
             extraArgs = "-w '\\n%{http_code}' -c '${cookieFile}'";
-            data = "$AUTH_PAYLOAD_FILE";
+            data = "@$AUTH_PAYLOAD_FILE";
           }
         } 2>/dev/null || echo -e "\n000")
         rm -f "$AUTH_PAYLOAD_FILE"


### PR DESCRIPTION
This mus have slipped when https://github.com/kiriwalawren/nixflix/pull/77 was merged.

The jellyseerr -> jellyfin auth fails during `jellyseerr-setup.service` right now. 

Interesting that the ci test did not catch this.