### PR TITLE
fix secret values with special chars being mangled by ConfigObj

### DIFF
--- a/lib/secrets/mergeSecrets.py
+++ b/lib/secrets/mergeSecrets.py
@@ -24,7 +24,10 @@ def merge_secrets(template_path: str, output_path: str):
 
     def replace_secret(match):
         secret_path = match.group(1)
-        return read_secret_file(secret_path)
+        value = read_secret_file(secret_path)
+        # Triple-double-quote to protect against ConfigObj special chars
+        # (commas trigger list parsing, quotes trigger string parsing)
+        return '"""' + value + '"""'
 
     result = re.sub(pattern, replace_secret, template)
 

--- a/tests/vm-tests/sabnzbd-basic.nix
+++ b/tests/vm-tests/sabnzbd-basic.nix
@@ -55,7 +55,7 @@ pkgsUnfree.testers.runNixOSTest {
                   _secret = pkgs.writeText "eweka-username" "testuser";
                 };
                 password = {
-                  _secret = pkgs.writeText "eweka-password" "testpass123";
+                  _secret = pkgs.writeText "eweka-password" "test,pass'123";
                 };
                 connections = 10;
                 ssl = true;
@@ -145,7 +145,7 @@ pkgsUnfree.testers.runNixOSTest {
     assert "host = news.example.com" in config_content, "Server host not set"
     assert "port = 563" in config_content, "Server port not set"
     assert "testuser" in config_content, "Username not set"
-    assert "testpass123" in config_content, "Password not set"
+    assert "\"test,pass'123\"" in config_content, "Password with special chars not preserved correctly"
     assert "connections = 10" in config_content, "Server connections not set"
     assert "ssl = 1" in config_content, "SSL not enabled"
     assert "priority = 0" in config_content, "Server priority not set"


### PR DESCRIPTION
Triple-double-quote merged secrets so ConfigObj preserves commas and quotes literally instead of interpreting them as list separators or string delimiters.

I put comma and single quote in the sabnzbd test password to test for it as requested. Let me know if you need changes, and thanks for your work on this project :)

Resolves #110 