### PR TITLE
support remote Jellyfin instances for Jellyseerr authentication

### DIFF
--- a/modules/jellyseerr/authUtil.nix
+++ b/modules/jellyseerr/authUtil.nix
@@ -2,19 +2,15 @@
   lib,
   pkgs,
   cfg,
-  jellyfinCfg,
 }:
 with lib;
 let
   secrets = import ../../lib/secrets { inherit lib; };
   mkSecureCurl = import ../../lib/mk-secure-curl.nix { inherit lib pkgs; };
-  adminUsers = filterAttrs (_: user: user.policy.isAdministrator) jellyfinCfg.users;
-  sortedAdminNames = sort (a: b: a < b) (attrNames adminUsers);
-  firstAdminName = head sortedAdminNames;
-  firstAdminUser = adminUsers.${firstAdminName};
+  inherit (cfg.jellyfin) adminUsername;
 
   jqAuthSecrets = secrets.mkJqSecretArgs {
-    inherit (firstAdminUser) password;
+    password = cfg.jellyfin.adminPassword;
   };
 
   baseUrl = "http://127.0.0.1:${toString cfg.port}";
@@ -63,14 +59,14 @@ in
 
     # Authenticate if needed
     if [ "$NEED_AUTH" = "true" ]; then
-      echo "Authenticating to Jellyseerr as ${firstAdminName}..."
+      echo "Authenticating to Jellyseerr as ${adminUsername}..."
 
       BACKOFF=1
       for attempt in {1..10}; do
         AUTH_PAYLOAD_FILE=$(mktemp)
         ${pkgs.jq}/bin/jq -n \
           ${jqAuthSecrets.flagsString} \
-          --arg username "${firstAdminName}" \
+          --arg username "${adminUsername}" \
           '{username: $username, password: ${jqAuthSecrets.refs.password}}' > "$AUTH_PAYLOAD_FILE"
 
         AUTH_RESPONSE=$(${

--- a/modules/jellyseerr/default.nix
+++ b/modules/jellyseerr/default.nix
@@ -36,8 +36,8 @@ in
       in
       [
         {
-          assertion = config.nixflix.jellyfin.enable;
-          message = "Jellyseerr requires Jellyfin to be enabled. Please set nixflix.jellyfin.enable = true.";
+          assertion = cfg.jellyfin.adminUsername != null && cfg.jellyfin.adminPassword != null;
+          message = "Jellyseerr requires Jellyfin admin credentials. Either enable nixflix.jellyfin with an admin user, or set nixflix.jellyseerr.jellyfin.adminUsername and nixflix.jellyseerr.jellyfin.adminPassword.";
         }
         {
           assertion = cfg.vpn.enable -> config.nixflix.mullvad.enable;

--- a/modules/jellyseerr/jellyfinService.nix
+++ b/modules/jellyseerr/jellyfinService.nix
@@ -8,19 +8,17 @@ with lib;
 let
   inherit (config) nixflix;
   cfg = nixflix.jellyseerr;
-  jellyfinCfg = nixflix.jellyfin;
   authUtil = import ./authUtil.nix {
     inherit
       lib
       pkgs
       cfg
-      jellyfinCfg
       ;
   };
   baseUrl = "http://127.0.0.1:${toString cfg.port}";
 in
 {
-  config = mkIf (nixflix.enable && cfg.enable && nixflix.jellyfin.enable) {
+  config = mkIf (nixflix.enable && cfg.enable) {
     systemd.services.jellyseerr-jellyfin = {
       description = "Configure Jellyfin settings in Jellyseerr";
       after = [

--- a/modules/jellyseerr/librarySyncService.nix
+++ b/modules/jellyseerr/librarySyncService.nix
@@ -8,31 +8,29 @@ with lib;
 let
   inherit (config) nixflix;
   cfg = nixflix.jellyseerr;
-  jellyfinCfg = nixflix.jellyfin;
   authUtil = import ./authUtil.nix {
     inherit
       lib
       pkgs
       cfg
-      jellyfinCfg
       ;
   };
   baseUrl = "http://127.0.0.1:${toString cfg.port}";
 in
 {
-  config = mkIf (nixflix.enable && cfg.enable && nixflix.jellyfin.enable) {
+  config = mkIf (nixflix.enable && cfg.enable) {
     systemd.services.jellyseerr-libraries = {
       description = "Sync Jellyseerr library selections";
       after = [
         "jellyseerr-setup.service"
         "jellyseerr-jellyfin.service"
-        "jellyfin-libraries.service"
-      ];
+      ]
+      ++ optional nixflix.jellyfin.enable "jellyfin-libraries.service";
       requires = [
         "jellyseerr-setup.service"
         "jellyseerr-jellyfin.service"
-        "jellyfin-libraries.service"
-      ];
+      ]
+      ++ optional nixflix.jellyfin.enable "jellyfin-libraries.service";
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {

--- a/modules/jellyseerr/options/jellyfin.nix
+++ b/modules/jellyseerr/options/jellyfin.nix
@@ -4,8 +4,40 @@
   ...
 }:
 with lib;
+let
+  secrets = import ../../../lib/secrets { inherit lib; };
+  jellyfinCfg = config.nixflix.jellyfin;
+  adminUsers = filterAttrs (_: user: user.policy.isAdministrator) jellyfinCfg.users;
+  sortedAdminNames = sort (a: b: a < b) (attrNames adminUsers);
+  hasLocalAdmin = jellyfinCfg.enable && sortedAdminNames != [ ];
+  firstAdminName = if hasLocalAdmin then head sortedAdminNames else null;
+  firstAdminUser = if hasLocalAdmin then adminUsers.${firstAdminName} else null;
+in
 {
   options.nixflix.jellyseerr.jellyfin = {
+    adminUsername = mkOption {
+      type = types.nullOr types.str;
+      default = firstAdminName;
+      defaultText = literalExpression "first admin username from nixflix.jellyfin.users, or null";
+      description = ''
+        Jellyfin admin username for Jellyseerr authentication.
+
+        Auto-derived from `nixflix.jellyfin.users` when Jellyfin is enabled locally.
+        Must be set explicitly when using a remote Jellyfin instance.
+      '';
+    };
+
+    adminPassword = secrets.mkSecretOption {
+      default = if hasLocalAdmin then firstAdminUser.password else null;
+      defaultText = literalExpression "password of first admin from nixflix.jellyfin.users, or null";
+      description = ''
+        Jellyfin admin password for Jellyseerr authentication.
+
+        Auto-derived from `nixflix.jellyfin.users` when Jellyfin is enabled locally.
+        Must be set explicitly when using a remote Jellyfin instance.
+      '';
+    };
+
     hostname = mkOption {
       type = types.str;
       default = "127.0.0.1";

--- a/modules/jellyseerr/radarrService.nix
+++ b/modules/jellyseerr/radarrService.nix
@@ -9,13 +9,11 @@ let
   secrets = import ../../lib/secrets { inherit lib; };
   inherit (config) nixflix;
   cfg = nixflix.jellyseerr;
-  jellyfinCfg = nixflix.jellyfin;
   authUtil = import ./authUtil.nix {
     inherit
       lib
       pkgs
       cfg
-      jellyfinCfg
       ;
   };
   baseUrl = "http://127.0.0.1:${toString cfg.port}";

--- a/modules/jellyseerr/setupService.nix
+++ b/modules/jellyseerr/setupService.nix
@@ -9,38 +9,31 @@ let
   secrets = import ../../lib/secrets { inherit lib; };
   inherit (config) nixflix;
   cfg = nixflix.jellyseerr;
-  jellyfinCfg = nixflix.jellyfin;
-
-  adminUsers = filterAttrs (_: user: user.policy.isAdministrator) jellyfinCfg.users;
-  sortedAdminNames = sort (a: b: a < b) (attrNames adminUsers);
-  firstAdminName = head sortedAdminNames;
-  firstAdminUser = adminUsers.${firstAdminName};
 
   authUtil = import ./authUtil.nix {
     inherit
       lib
       pkgs
       cfg
-      jellyfinCfg
       ;
   };
   baseUrl = "http://127.0.0.1:${toString cfg.port}";
   jqSetupSecrets = secrets.mkJqSecretArgs {
-    inherit (firstAdminUser) password;
+    password = cfg.jellyfin.adminPassword;
   };
 in
 {
-  config = mkIf (nixflix.enable && cfg.enable && nixflix.jellyfin.enable) {
+  config = mkIf (nixflix.enable && cfg.enable) {
     systemd.services.jellyseerr-setup = {
       description = "Complete Jellyseerr initial setup with Jellyfin";
       after = [
         "jellyseerr.service"
-        "jellyfin-setup-wizard.service"
-      ];
+      ]
+      ++ optional nixflix.jellyfin.enable "jellyfin-setup-wizard.service";
       requires = [
         "jellyseerr.service"
-        "jellyfin-setup-wizard.service"
-      ];
+      ]
+      ++ optional nixflix.jellyfin.enable "jellyfin-setup-wizard.service";
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
@@ -75,15 +68,14 @@ in
         echo "Running initial setup..."
 
         # Step 1: Connect to Jellyfin (this creates the session cookie)
-        # Use Jellyfin's first admin credentials
         SETUP_PAYLOAD=$(${pkgs.jq}/bin/jq -n \
           ${jqSetupSecrets.flagsString} \
-          --arg username "${firstAdminName}" \
+          --arg username "${cfg.jellyfin.adminUsername}" \
           --arg hostname "${cfg.jellyfin.hostname}" \
           --arg port "${toString cfg.jellyfin.port}" \
           --arg useSsl "${boolToString cfg.jellyfin.useSsl}" \
           --arg urlBase "${cfg.jellyfin.urlBase}" \
-          --arg email "${firstAdminUser.email or firstAdminName}" \
+          --arg email "${cfg.jellyfin.adminUsername}" \
           --arg serverType "${toString cfg.jellyfin.serverType}" \
           '{
             username: $username,

--- a/modules/jellyseerr/sonarrService.nix
+++ b/modules/jellyseerr/sonarrService.nix
@@ -9,13 +9,11 @@ let
   secrets = import ../../lib/secrets { inherit lib; };
   inherit (config) nixflix;
   cfg = nixflix.jellyseerr;
-  jellyfinCfg = nixflix.jellyfin;
   authUtil = import ./authUtil.nix {
     inherit
       lib
       pkgs
       cfg
-      jellyfinCfg
       ;
   };
   baseUrl = "http://127.0.0.1:${toString cfg.port}";

--- a/modules/jellyseerr/userSettingsService.nix
+++ b/modules/jellyseerr/userSettingsService.nix
@@ -8,20 +8,18 @@ with lib;
 let
   inherit (config) nixflix;
   cfg = nixflix.jellyseerr;
-  jellyfinCfg = nixflix.jellyfin;
   authUtil = import ./authUtil.nix {
     inherit
       lib
       pkgs
       cfg
-      jellyfinCfg
       ;
   };
   baseUrl = "http://127.0.0.1:${toString cfg.port}";
   userSettings = cfg.settings.users;
 in
 {
-  config = mkIf (nixflix.enable && cfg.enable && nixflix.jellyfin.enable) {
+  config = mkIf (nixflix.enable && cfg.enable) {
     systemd.services.jellyseerr-user-settings = {
       description = "Configure Jellyseerr default user settings";
       after = [ "jellyseerr-setup.service" ];

--- a/tests/unit-tests/default.nix
+++ b/tests/unit-tests/default.nix
@@ -242,6 +242,36 @@ in
     in
     assertTest "sabnzbd-service-generation" hasAllServices;
 
+  # Test that jellyseerr generates services with a remote Jellyfin (no local jellyfin)
+  jellyseerr-remote-jellyfin =
+    let
+      config = evalConfig [
+        {
+          nixflix = {
+            enable = true;
+            jellyseerr = {
+              enable = true;
+              apiKey = {
+                _secret = "/run/secrets/jellyseerr-api";
+              };
+              jellyfin = {
+                adminUsername = "remoteadmin";
+                adminPassword = "remotepassword";
+              };
+            };
+          };
+        }
+      ];
+      systemdUnits = config.config.systemd.services;
+    in
+    assertTest "jellyseerr-remote-jellyfin" (
+      systemdUnits ? jellyseerr
+      && systemdUnits ? jellyseerr-setup
+      && systemdUnits ? jellyseerr-jellyfin
+      && systemdUnits ? jellyseerr-libraries
+      && systemdUnits ? jellyseerr-user-settings
+    );
+
   jellyfin-integration =
     let
       config = evalConfig [


### PR DESCRIPTION
Closes #124   (hopefully :)

This touches a lot of files so I'm happy to continue refining it if it doesn't conform to standards. Just wanted to show you the diff for reference.

Add adminUsername and adminPassword options to jellyseerr.jellyfin with computed defaults that auto-derive from nixflix.jellyfin.users when Jellyfin is co-located. When Jellyfin runs on a separate host, these can be set explicitly.

- Add credential options with computed defaults in options/jellyfin.nix
- Replace jellyfin.enable assertion with credential null check
- Remove jellyfinCfg parameter from authUtil.nix
- Make jellyfin-related systemd deps conditional on nixflix.jellyfin.enable
- Remove nixflix.jellyfin.enable gates from service mkIf conditions