### PR TITLE
fix: scope postgres usage to nixflix.postgres.enable

### DIFF
--- a/modules/arr-common/mkArrServiceModule.nix
+++ b/modules/arr-common/mkArrServiceModule.nix
@@ -130,7 +130,7 @@ in
           server = {
             inherit (config.nixflix.${serviceName}.config.hostConfig) port urlBase;
           };
-        } // optionalAttrs config.services.postgresql.enable {
+        } // optionalAttrs config.nixflix.postgres.enable {
           log.dbEnabled = true;
           postgres = {
             user = config.nixflix.${serviceName}.user;
@@ -215,7 +215,7 @@ in
         };
         server = { inherit (cfg.config.hostConfig) port urlBase; };
       }
-      // optionalAttrs config.services.postgresql.enable {
+      // optionalAttrs config.nixflix.postgres.enable {
         log.dbEnabled = true;
         postgres = {
           inherit (cfg) user;
@@ -236,7 +236,7 @@ in
     };
 
     services = {
-      postgresql = mkIf config.services.postgresql.enable {
+      postgresql = mkIf config.nixflix.postgres.enable {
         ensureDatabases = [
           cfg.settings.postgres.mainDb
           cfg.settings.postgres.logDb
@@ -314,7 +314,7 @@ in
     );
 
     systemd.services = {
-      "${serviceName}-setup-logs-db" = mkIf config.services.postgresql.enable {
+      "${serviceName}-setup-logs-db" = mkIf config.nixflix.postgres.enable {
         description = "Grant ownership of ${capitalizedName} databases";
         after = [
           "postgresql.service"
@@ -340,7 +340,7 @@ in
         '';
       };
 
-      "${serviceName}-wait-for-db" = mkIf config.services.postgresql.enable {
+      "${serviceName}-wait-for-db" = mkIf config.nixflix.postgres.enable {
         description = "Wait for ${capitalizedName} PostgreSQL databases to be ready";
         after = [
           "postgresql.service"
@@ -381,7 +381,7 @@ in
         ++ (optional (
           cfg.config.apiKey != null && cfg.config.hostConfig.password != null
         ) "${serviceName}-env.service")
-        ++ (optional config.services.postgresql.enable "postgresql-ready.target")
+        ++ (optional config.nixflix.postgres.enable "postgresql-ready.target")
         ++ (optional config.nixflix.mullvad.enable "mullvad-config.service");
         requires = [
           "nixflix-setup-dirs.service"
@@ -389,7 +389,7 @@ in
         ++ (optional (
           cfg.config.apiKey != null && cfg.config.hostConfig.password != null
         ) "${serviceName}-env.service")
-        ++ (optional config.services.postgresql.enable "postgresql-ready.target");
+        ++ (optional config.nixflix.postgres.enable "postgresql-ready.target");
         wants = optional config.nixflix.mullvad.enable "mullvad-config.service";
         wantedBy = [ "multi-user.target" ];
 

--- a/modules/jellyseerr/default.nix
+++ b/modules/jellyseerr/default.nix
@@ -89,7 +89,7 @@ in
       };
     };
 
-    services.postgresql = mkIf config.services.postgresql.enable {
+    services.postgresql = mkIf config.nixflix.postgres.enable {
       ensureDatabases = [ cfg.user ];
       ensureUsers = [
         {
@@ -118,7 +118,7 @@ in
         '';
       };
 
-      jellyseerr-wait-for-db = mkIf config.services.postgresql.enable {
+      jellyseerr-wait-for-db = mkIf config.nixflix.postgres.enable {
         description = "Wait for Jellyseerr PostgreSQL database to be ready";
         after = [
           "postgresql.service"
@@ -160,7 +160,7 @@ in
           "jellyfin.service"
           "jellyfin-setup-wizard.service"
         ]
-        ++ optional config.services.postgresql.enable "postgresql-ready.target"
+        ++ optional config.nixflix.postgres.enable "postgresql-ready.target"
         ++ optional config.nixflix.recyclarr.enable "recyclarr.service"
         ++ optional (
           config.nixflix.recyclarr.enable && config.nixflix.recyclarr.cleanupUnmanagedProfiles.enable
@@ -180,7 +180,7 @@ in
           "jellyfin-setup-wizard.service"
         ]
         ++ optional (cfg.apiKey != null) "jellyseerr-env.service"
-        ++ optional config.services.postgresql.enable "postgresql-ready.target"
+        ++ optional config.nixflix.postgres.enable "postgresql-ready.target"
         ++ optional (
           config.nixflix.recyclarr.enable && config.nixflix.recyclarr.cleanupUnmanagedProfiles.enable
         ) "recyclarr-cleanup-profiles.service";
@@ -192,7 +192,7 @@ in
           PORT = toString cfg.port;
           CONFIG_DIRECTORY = cfg.dataDir;
         }
-        // optionalAttrs config.services.postgresql.enable {
+        // optionalAttrs config.nixflix.postgres.enable {
           DB_TYPE = "postgres";
           DB_SOCKET_PATH = "/run/postgresql";
           DB_USER = cfg.user;


### PR DESCRIPTION
Previously, jellyseerr and arr services would automatically use postgres whenever services.postgresql.enable was true even if postgres was running for an unrelated service (e.g. Immich). This caused jellyseerr to try to use an external postgres cluster it had no control over, resulting in empty user tables and broken initial setup.

Scope all postgres-conditional logic to `config.nixflix.postgres.enable` so that postgres is only used when nixflix's own postgres module is explicitly enabled.