### PR TITLE
fix download client timing issue

### DIFF
--- a/modules/downloadarr/service.nix
+++ b/modules/downloadarr/service.nix
@@ -184,17 +184,27 @@ let
 
                 UPDATED_CLIENT=$(apply_field_overrides "$EXISTING_CLIENT" "$FIELD_OVERRIDES")
 
-                ${
-                  mkSecureCurl serviceConfig.apiKey {
-                    url = "$BASE_URL/downloadclient/$CLIENT_ID";
-                    method = "PUT";
-                    headers = {
-                      "Content-Type" = "application/json";
-                    };
-                    data = "$UPDATED_CLIENT";
-                    extraArgs = "-Sf";
-                  }
-                } >/dev/null
+                for _retry_attempt in $(seq 1 5); do
+                  if ${
+                    mkSecureCurl serviceConfig.apiKey {
+                      url = "$BASE_URL/downloadclient/$CLIENT_ID";
+                      method = "PUT";
+                      headers = {
+                        "Content-Type" = "application/json";
+                      };
+                      data = "$UPDATED_CLIENT";
+                      extraArgs = "-Sf";
+                    }
+                  } >/dev/null; then
+                    break
+                  fi
+                  if [ "$_retry_attempt" -eq 5 ]; then
+                    echo "Error: Failed to update download client ${clientName} after 5 attempts"
+                    exit 1
+                  fi
+                  echo "Attempt $_retry_attempt to update ${clientName} failed, retrying in 1 second..."
+                  sleep 1
+                done
 
                 echo "Download client ${clientName} updated"
               else
@@ -209,17 +219,27 @@ let
 
                 NEW_CLIENT=$(apply_field_overrides "$SCHEMA" "$FIELD_OVERRIDES")
 
-                ${
-                  mkSecureCurl serviceConfig.apiKey {
-                    url = "$BASE_URL/downloadclient";
-                    method = "POST";
-                    headers = {
-                      "Content-Type" = "application/json";
-                    };
-                    data = "$NEW_CLIENT";
-                    extraArgs = "-Sf";
-                  }
-                } >/dev/null
+                for _retry_attempt in $(seq 1 5); do
+                  if ${
+                    mkSecureCurl serviceConfig.apiKey {
+                      url = "$BASE_URL/downloadclient";
+                      method = "POST";
+                      headers = {
+                        "Content-Type" = "application/json";
+                      };
+                      data = "$NEW_CLIENT";
+                      extraArgs = "-Sf";
+                    }
+                  } >/dev/null; then
+                    break
+                  fi
+                  if [ "$_retry_attempt" -eq 5 ]; then
+                    echo "Error: Failed to create download client ${clientName} after 5 attempts"
+                    exit 1
+                  fi
+                  echo "Attempt $_retry_attempt to create ${clientName} failed, retrying in 1 second..."
+                  sleep 1
+                done
 
                 echo "Download client ${clientName} created"
               fi


### PR DESCRIPTION
Resolves #129

## Problem:

The downloadarr configuration systemd services were appropriately waiting for their respective
download client services to be ready first. However, `qbittorrent.service`, for example reports success
before the API is ready to accept requests.

## Solution:

This is actually something I have had to fight several times in this code base. It is very annoying.
Most of the time, I solve it by adding an ExecStartPost. But in this case, it was just easier to
add retry logic to the downloadarr services.
