### PR TITLE
Wire up serviceDependencies in Arr and Jellyfin services

### DIFF
--- a/modules/arr-common/mkArrServiceModule.nix
+++ b/modules/arr-common/mkArrServiceModule.nix
@@ -15,7 +15,12 @@ let
   mkWaitForApiScript = import ./mkWaitForApiScript.nix { inherit lib pkgs; };
   hostConfig = import ./hostConfig.nix { inherit lib pkgs serviceName; };
   rootFolders = import ./rootFolders.nix {
-    inherit config lib pkgs serviceName;
+    inherit
+      config
+      lib
+      pkgs
+      serviceName
+      ;
   };
   delayProfiles = import ./delayProfiles.nix { inherit lib pkgs serviceName; };
   capitalizedName = toUpper (substring 0 1 serviceName) + substring 1 (-1) serviceName;

--- a/modules/arr-common/mkArrServiceModule.nix
+++ b/modules/arr-common/mkArrServiceModule.nix
@@ -14,7 +14,9 @@ let
 
   mkWaitForApiScript = import ./mkWaitForApiScript.nix { inherit lib pkgs; };
   hostConfig = import ./hostConfig.nix { inherit lib pkgs serviceName; };
-  rootFolders = import ./rootFolders.nix { inherit lib pkgs serviceName; };
+  rootFolders = import ./rootFolders.nix {
+    inherit config lib pkgs serviceName;
+  };
   delayProfiles = import ./delayProfiles.nix { inherit lib pkgs serviceName; };
   capitalizedName = toUpper (substring 0 1 serviceName) + substring 1 (-1) serviceName;
   usesMediaDirs = !(elem serviceName [ "prowlarr" ]);
@@ -377,6 +379,7 @@ in
           "network.target"
           "nixflix-setup-dirs.service"
         ]
+        ++ config.nixflix.serviceDependencies
         ++ (optional (
           cfg.config.apiKey != null && cfg.config.hostConfig.password != null
         ) "${serviceName}-env.service")
@@ -385,6 +388,7 @@ in
         requires = [
           "nixflix-setup-dirs.service"
         ]
+        ++ config.nixflix.serviceDependencies
         ++ (optional (
           cfg.config.apiKey != null && cfg.config.hostConfig.password != null
         ) "${serviceName}-env.service")

--- a/modules/arr-common/rootFolders.nix
+++ b/modules/arr-common/rootFolders.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   serviceName,
@@ -26,8 +27,8 @@ in
 
   mkService = serviceConfig: {
     description = "Configure ${serviceName} root folders via API";
-    after = [ "${serviceName}-config.service" ];
-    requires = [ "${serviceName}-config.service" ];
+    after = [ "${serviceName}-config.service" ] ++ config.nixflix.serviceDependencies;
+    requires = [ "${serviceName}-config.service" ] ++ config.nixflix.serviceDependencies;
     wantedBy = [ "multi-user.target" ];
 
     serviceConfig = {

--- a/modules/jellyfin/default.nix
+++ b/modules/jellyfin/default.nix
@@ -134,7 +134,9 @@ in
       after = [
         "network-online.target"
         "nixflix-setup-dirs.service"
-      ];
+      ]
+      ++ config.nixflix.serviceDependencies;
+      requires = config.nixflix.serviceDependencies;
       wants = [
         "network-online.target"
         "nixflix-setup-dirs.service"

--- a/modules/jellyfin/librariesService.nix
+++ b/modules/jellyfin/librariesService.nix
@@ -49,8 +49,8 @@ in
   config = mkIf (nixflix.enable && cfg.enable && cfg.libraries != { }) {
     systemd.services.jellyfin-libraries = {
       description = "Configure Jellyfin Libraries via API";
-      after = [ "jellyfin-setup-wizard.service" ];
-      requires = [ "jellyfin-setup-wizard.service" ];
+      after = [ "jellyfin-setup-wizard.service" ] ++ config.nixflix.serviceDependencies;
+      requires = [ "jellyfin-setup-wizard.service" ] ++ config.nixflix.serviceDependencies;
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {


### PR DESCRIPTION
The documented `nixflix.serviceDependencies` option is meant to let downstream configurations make media services wait for prerequisite systemd units such as mount units, but the Arr services, Arr root folder sync, the Jellyfin service, and Jellyfin library sync did not apply it.

This changes those units to append `serviceDependencies` to their `after` and `requires` settings so callers can rely on the documented option.
