### PR TITLE
WIP: Declarative jellyfin plugins

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,8 @@
         );
     in
     {
+      lib.buildJellyfinPlugin = { pkgs }: import ./lib/build-jellyfin-plugin.nix { inherit pkgs; };
+
       nixosModules.default = import ./modules;
       nixosModules.nixflix = import ./modules;
 

--- a/lib/build-jellyfin-plugin.nix
+++ b/lib/build-jellyfin-plugin.nix
@@ -1,0 +1,34 @@
+{ pkgs }:
+{
+  pname,
+  version,
+  src,
+  ...
+}@args:
+pkgs.stdenvNoCC.mkDerivation (
+  {
+    inherit pname version src;
+    nativeBuildInputs = [ pkgs.unzip ];
+    unpackPhase = ''
+      mkdir unpacked
+      unzip $src -d unpacked
+    '';
+    dontFixup = true;
+    installPhase = ''
+      # Handle single-directory zips: if unpacked contains exactly one
+      # directory and nothing else, use its contents instead
+      shopt -s nullglob dotglob
+      entries=(unpacked/*)
+      if [ "''${#entries[@]}" -eq 1 ] && [ -d "''${entries[0]}" ]; then
+        cp -a "''${entries[0]}" $out
+      else
+        cp -a unpacked $out
+      fi
+    '';
+  }
+  // removeAttrs args [
+    "pname"
+    "version"
+    "src"
+  ]
+)

--- a/modules/jellyfin/default.nix
+++ b/modules/jellyfin/default.nix
@@ -28,6 +28,7 @@ in
     ./brandingService.nix
     ./encodingService.nix
     ./librariesService.nix
+    ./pluginSyncService.nix
     ./setupWizardService.nix
     ./systemConfigService.nix
     ./usersConfigService.nix

--- a/modules/jellyfin/options/default.nix
+++ b/modules/jellyfin/options/default.nix
@@ -15,6 +15,7 @@ in
     ./branding.nix
     ./encoding.nix
     ./libraries.nix
+    ./plugins.nix
     ./system.nix
     ./users.nix
   ];

--- a/modules/jellyfin/options/plugins.nix
+++ b/modules/jellyfin/options/plugins.nix
@@ -1,0 +1,16 @@
+{ lib, ... }:
+with lib;
+{
+  options.nixflix.jellyfin.plugins = mkOption {
+    type = types.listOf types.package;
+    default = [ ];
+    description = ''
+      List of Jellyfin plugin packages to install declaratively.
+      Each package should produce a directory containing plugin files
+      (DLLs, etc.). Nixflix names the managed plugin directory from the
+      package name and version when present. Jellyfin auto-generates meta.json from assembly
+      attributes on first load.
+      Removing a plugin from this list removes it from disk on restart.
+    '';
+  };
+}

--- a/modules/jellyfin/pluginSyncService.nix
+++ b/modules/jellyfin/pluginSyncService.nix
@@ -1,0 +1,106 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  inherit (config) nixflix;
+  cfg = config.nixflix.jellyfin;
+
+  pluginDirName =
+    plugin:
+    let
+      version = getVersion plugin;
+      name = getName plugin;
+    in
+    if version == "" then name else "${name}_${version}";
+
+  pluginDirs = map pluginDirName cfg.plugins;
+
+  # Plain text dir names as a store file (avoids heredoc indentation bugs)
+  pluginDirsFile = pkgs.writeText "jellyfin-managed-plugins" (concatStringsSep "\n" pluginDirs);
+in
+{
+  config = mkIf (nixflix.enable && cfg.enable) {
+    assertions = [
+      {
+        assertion = length pluginDirs == length (unique pluginDirs);
+        message = "nixflix.jellyfin.plugins contains duplicate managed plugin directory names.";
+      }
+    ];
+
+    systemd.tmpfiles.settings."10-jellyfin"."${cfg.dataDir}/plugins".d = {
+      mode = "0755";
+      inherit (cfg) user;
+      inherit (cfg) group;
+    };
+
+    systemd.services.jellyfin-plugin-sync = {
+      description = "Sync Jellyfin plugins from Nix store";
+      after = [ "nixflix-setup-dirs.service" ];
+      requires = [ "nixflix-setup-dirs.service" ];
+      before = [ "jellyfin.service" ];
+      requiredBy = [ "jellyfin.service" ];
+      # PartOf propagates stop from jellyfin → sync stops too.
+      # Then Requires pulls sync back in before jellyfin starts.
+      # Result: sync re-runs on every jellyfin restart.
+      partOf = [ "jellyfin.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = cfg.user;
+        Group = cfg.group;
+      };
+
+      script = ''
+        set -eu
+        PLUGIN_DIR='${cfg.dataDir}/plugins'
+        MANIFEST="$PLUGIN_DIR/.nixflix-managed"
+
+        # Stage new manifest from Nix store
+        ${pkgs.coreutils}/bin/cp '${pluginDirsFile}' "$MANIFEST.new"
+
+        # Remove previously managed plugins no longer declared
+        if [ -f "$MANIFEST" ]; then
+          while IFS= read -r old_dir; do
+            [ -z "$old_dir" ] && continue
+            found=0
+            while IFS= read -r new_dir; do
+              if [ "$old_dir" = "$new_dir" ]; then
+                found=1
+                break
+              fi
+            done < "$MANIFEST.new"
+            if [ "$found" = 0 ] && [ -d "$PLUGIN_DIR/$old_dir" ]; then
+              ${pkgs.coreutils}/bin/rm -rf "$PLUGIN_DIR/$old_dir"
+              echo "Removed plugin: $old_dir"
+            fi
+          done < "$MANIFEST"
+        fi
+
+        # Install declared plugins
+        ${concatMapStringsSep "\n" (
+          plugin:
+          let
+            dirName = pluginDirName plugin;
+          in
+          ''
+            TARGET="$PLUGIN_DIR/${dirName}"
+            ${pkgs.coreutils}/bin/rm -rf "$TARGET"
+            ${pkgs.coreutils}/bin/mkdir -p "$TARGET"
+            ${pkgs.coreutils}/bin/cp -a '${plugin}'/. "$TARGET/"
+            ${pkgs.coreutils}/bin/chmod -R u+w "$TARGET"
+          ''
+        ) cfg.plugins}
+
+        # Activate new manifest
+        ${pkgs.coreutils}/bin/mv "$MANIFEST.new" "$MANIFEST"
+        echo "Plugin sync complete: ${toString (length cfg.plugins)} plugins managed"
+      '';
+    };
+  };
+}

--- a/tests/unit-tests/default.nix
+++ b/tests/unit-tests/default.nix
@@ -244,6 +244,72 @@ in
       && systemdUnits ? seerr-user-settings
     );
 
+  jellyfin-plugin-service-generation =
+    let
+      plugin = pkgs.runCommand "test-plugin-1.0.0" { } ''
+        mkdir -p "$out"
+        touch "$out/TestPlugin.dll"
+      '';
+      config = evalConfig [
+        {
+          nixflix = {
+            enable = true;
+
+            jellyfin = {
+              enable = true;
+              plugins = [ plugin ];
+              users.admin = {
+                password = "testpassword";
+                policy.isAdministrator = true;
+              };
+            };
+          };
+        }
+      ];
+      systemdUnits = config.config.systemd.services;
+      tmpfilesSettings = config.config.systemd.tmpfiles.settings;
+      pluginPath = "${config.config.nixflix.jellyfin.dataDir}/plugins";
+      syncService = systemdUnits.jellyfin-plugin-sync;
+    in
+    pkgs.runCommand "unit-test-jellyfin-plugin-service-generation" { } ''
+      ${check "plugin sync service exists" (systemdUnits ? jellyfin-plugin-sync)}
+      ${check "plugin sync runs before jellyfin" (builtins.elem "jellyfin.service" syncService.before)}
+      ${check "plugin sync is required by jellyfin" (
+        builtins.elem "jellyfin.service" syncService.requiredBy
+      )}
+      ${check "plugin sync remains after exit" syncService.serviceConfig.RemainAfterExit}
+      ${check "plugin tmpfiles directory exists" (builtins.hasAttr pluginPath tmpfilesSettings."10-jellyfin")}
+
+      echo 'PASS: jellyfin-plugin-service-generation' > $out
+    '';
+
+  jellyfin-plugin-empty-list-service-generation =
+    let
+      config = evalConfig [
+        {
+          nixflix = {
+            enable = true;
+
+            jellyfin = {
+              enable = true;
+              plugins = [ ];
+              users.admin = {
+                password = "testpassword";
+                policy.isAdministrator = true;
+              };
+            };
+          };
+        }
+      ];
+      systemdUnits = config.config.systemd.services;
+    in
+    pkgs.runCommand "unit-test-jellyfin-plugin-empty-list-service-generation" { } ''
+      ${check "plugin sync service exists when plugin list is empty" (
+        systemdUnits ? jellyfin-plugin-sync
+      )}
+      echo 'PASS: jellyfin-plugin-empty-list-service-generation' > $out
+    '';
+
   jellyfin-integration =
     let
       config = evalConfig [

--- a/tests/vm-tests/jellyfin-basic.nix
+++ b/tests/vm-tests/jellyfin-basic.nix
@@ -3,6 +3,12 @@
   pkgs ? import <nixpkgs> { inherit system; },
   nixosModules,
 }:
+let
+  testPlugin = pkgs.runCommand "test-plugin-1.0.0" { } ''
+    mkdir -p "$out"
+    touch "$out/TestPlugin.dll"
+  '';
+in
 pkgs.testers.runNixOSTest {
   name = "jellyfin-users";
 
@@ -23,6 +29,7 @@ pkgs.testers.runNixOSTest {
           enable = true;
 
           apiKey._secret = pkgs.writeText "jellyfin-apikey" "jellyfinApiKey1111111111111111111";
+          plugins = [ testPlugin ];
 
           users = {
             admin = {
@@ -390,6 +397,10 @@ pkgs.testers.runNixOSTest {
     machine.wait_for_unit("jellyfin-system-config.service", timeout=180)
     machine.wait_for_unit("jellyfin-encoding-config.service", timeout=180)
     machine.wait_for_unit("jellyfin-branding-config.service", timeout=180)
+    machine.wait_for_unit("jellyfin-plugin-sync.service", timeout=180)
+
+    machine.succeed("test -d /data/.state/jellyfin/plugins/test-plugin_1.0.0")
+    machine.succeed("test -f /data/.state/jellyfin/plugins/test-plugin_1.0.0/TestPlugin.dll")
 
     api_token = machine.succeed("cat /run/jellyfin/auth-token")
     auth_header = f'"Authorization: {api_token}"'


### PR DESCRIPTION
- Add declarative Jellyfin plugin support to nixflix via a new `nixflix.jellyfin.plugins` option
-  expose a `buildJellyfinPlugin` helper and sync managed plugin directories before Jellyfin starts
- add unit and VM test coverage for plugin syncing so plugin installs/removals stay reproducible

This makes Jellyfin plugins reproducible and Nix-managed instead of being manually installed in the UI. It also allows plugin updates and removals to follow normal config changes and restarts.

---
Still at the proof of concept stage but working for my limited use case. If this isn't the direction you think is appropriate please let me know, happy to close or overhaul. 
The config I tested with:
``` 
       plugins =
          let
            buildPlugin = inputs.nixflix.lib.buildJellyfinPlugin { inherit pkgs; };
          in
          [
            (buildPlugin {
              pname = "intro-skipper";
              version = "1.10.11.16";
              src = pkgs.fetchurl {
                url = "https://github.com/intro-skipper/intro-skipper/releases/download/10.11/v1.
10.11.16/intro-skipper-v1.10.11.16.zip";
                hash = "sha256-hdxBtrB6TLNSlh0Jz27Qr6QnPsXExcbvMJh/b9LrZxA=";
              };
            })
            (buildPlugin {
              pname = "media-bar";
              version = "2.4.8.1";
              src = pkgs.fetchurl {
                url = "https://github.com/IAmParadox27/jellyfin-plugin-media-bar/releases/downloa
d/2.4.8.1/Release-10.11.6.zip";
                hash = "sha256-UNO3IRqiD4qFq5GLrz0p1MIJcQ8tPuHFhrU1TUUbDs0=";
              };
            })
            (buildPlugin {
              pname = "file-transformation";
              version = "2.5.5.0";
              src = pkgs.fetchurl {
                url = "https://github.com/IAmParadox27/jellyfin-plugin-file-transformation/releas
es/download/2.5.5.0/Release-10.11.6.zip";
                hash = "sha256-RVBvwku0Hi3aj9F90dFDHsjwtHc878hw5GyDD+8Nupo=";
              };
            })
          ];
```