### PR TITLE
recyclarr: only require and schedule sonarr-anime services when sonarr-anime is enabled

### DIFF
--- a/modules/recyclarr/default.nix
+++ b/modules/recyclarr/default.nix
@@ -165,7 +165,7 @@ in
           "sonarr.service"
           "sonarr-config.service"
         ]
-        ++ optionals config.nixflix.sonarr.enable [
+        ++ optionals config.nixflix.sonarr-anime.enable [
           "sonarr-anime.service"
           "sonarr-anime-config.service"
         ];
@@ -178,7 +178,7 @@ in
             "sonarr.service"
             "sonarr-config.service"
           ]
-          ++ optionals config.nixflix.sonarr.enable [
+          ++ optionals config.nixflix.sonarr-anime.enable [
             "sonarr-anime.service"
             "sonarr-anime-config.service"
           ];


### PR DESCRIPTION
`recyclarr.timer` currently fails when Sonarr is enabled and Sonarr-Anime isn't.

```
Apr 07 21:15:22 lokottara systemd[1]: Started Recyclarr Timer.
Apr 07 21:15:22 lokottara systemd[1]: recyclarr.timer: Failed to queue unit startup job: Unit sonarr-anime.service not found.
Apr 07 21:15:22 lokottara systemd[1]: recyclarr.timer: Failed with result 'resources'.