### PR TITLE
[BREAKING] recyclarr: update options schema to v8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {

--- a/modules/recyclarr/cleanup-profiles.nix
+++ b/modules/recyclarr/cleanup-profiles.nix
@@ -110,14 +110,26 @@ in
                       else
                         echo "  Found $PROFILE_COUNT unmanaged profile(s) to delete"
 
-                        # Get the first managed profile to use as default for reassignment
-                        DEFAULT_PROFILE_NAME=$(echo "$MANAGED_PROFILES" | ${pkgs.jq}/bin/jq -r '.[0]')
-                        DEFAULT_PROFILE_ID=$(echo "$ALL_PROFILES" | ${pkgs.jq}/bin/jq -r --arg name "$DEFAULT_PROFILE_NAME" '
-                          map(select(.name == $name)) | .[0].id
-                        ')
+                        # Find the first managed profile that actually exists in this
+                        # instance — managedProfiles is a single list used for every
+                        # Sonarr/Radarr instance, so e.g. a radarr-only "[SQP] SQP-1 (1080p)"
+                        # must be skipped when cleaning up sonarr.
+                        DEFAULT_PROFILE_NAME=""
+                        DEFAULT_PROFILE_ID=""
+                        while IFS= read -r candidate; do
+                          [ -n "$candidate" ] || continue
+                          candidate_id=$(echo "$ALL_PROFILES" | ${pkgs.jq}/bin/jq -r --arg name "$candidate" '
+                            map(select(.name == $name)) | .[0].id // empty
+                          ')
+                          if [ -n "$candidate_id" ] && [ "$candidate_id" != "null" ]; then
+                            DEFAULT_PROFILE_NAME="$candidate"
+                            DEFAULT_PROFILE_ID="$candidate_id"
+                            break
+                          fi
+                        done < <(echo "$MANAGED_PROFILES" | ${pkgs.jq}/bin/jq -r '.[]')
 
-                        if [ -z "$DEFAULT_PROFILE_ID" ] || [ "$DEFAULT_PROFILE_ID" = "null" ]; then
-                          echo "  ERROR: Could not find default managed profile '$DEFAULT_PROFILE_NAME'"
+                        if [ -z "$DEFAULT_PROFILE_ID" ]; then
+                          echo "  ERROR: None of the managed profiles exist in ${instance.instanceName}; skipping cleanup"
                         else
                           echo "  Default profile for reassignment: $DEFAULT_PROFILE_NAME (ID: $DEFAULT_PROFILE_ID)"
 

--- a/modules/recyclarr/config-option.nix
+++ b/modules/recyclarr/config-option.nix
@@ -105,12 +105,6 @@ let
           description = "Whether to delete custom formats in the service that are not defined in the configuration.";
         };
 
-        replace_existing_custom_formats = mkOption {
-          type = types.bool;
-          default = true;
-          description = "Whether to replace existing custom formats with configuration from Recyclarr.";
-        };
-
         quality_definition = mkOption {
           type = types.nullOr (
             types.submodule {
@@ -120,6 +114,8 @@ let
                     [
                       "movie"
                       "anime"
+                      "sqp-streaming"
+                      "sqp-uhd"
                     ]
                   else
                     [
@@ -133,6 +129,29 @@ let
           );
           default = null;
           description = "Quality definition configuration from TRaSH guides.";
+        };
+
+        media_management = mkOption {
+          type = types.nullOr (
+            types.submodule {
+              options.propers_and_repacks = mkOption {
+                type = types.nullOr (
+                  types.enum [
+                    "prefer_and_upgrade"
+                    "do_not_upgrade"
+                    "do_not_prefer"
+                  ]
+                );
+                default = null;
+                description = ''
+                  How to handle Propers and Repacks. Set to `do_not_prefer` when using
+                  Custom Formats for repack/proper handling.
+                '';
+              };
+            }
+          );
+          default = null;
+          description = "Media management settings.";
         };
 
         media_naming = mkOption {
@@ -151,19 +170,55 @@ let
           type = types.listOf (
             types.submodule {
               options = {
+                trash_id = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    The trash_id of a guide-backed quality profile. When specified, qualities,
+                    custom formats, scores, and language are automatically configured from the
+                    TRaSH Guides.
+                  '';
+                  example = "0896c29d74de619df168d23b98104b22";
+                };
+
                 name = mkOption {
-                  type = types.str;
-                  description = "Name of the quality profile";
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    Name of the quality profile. For guide-backed profiles (with `trash_id`),
+                    this overrides the guide name. For user-defined profiles, this is the
+                    profile identity. Either `trash_id` or `name` is required.
+                  '';
                   example = "WEB-2160p";
+                };
+
+                score_set = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = "The set of scores to use for custom formats assigned to the profile.";
                 };
 
                 reset_unmatched_scores = mkOption {
                   type = types.nullOr (
                     types.submodule {
-                      options.enabled = mkOption {
-                        type = types.bool;
-                        default = true;
-                        description = "Whether to reset scores for custom formats not in the configuration.";
+                      options = {
+                        enabled = mkOption {
+                          type = types.bool;
+                          default = true;
+                          description = "Whether to reset scores for custom formats not in the configuration.";
+                        };
+
+                        except = mkOption {
+                          type = types.nullOr (types.listOf types.str);
+                          default = null;
+                          description = "Custom format names to exclude when resetting scores (case-insensitive).";
+                        };
+
+                        except_patterns = mkOption {
+                          type = types.nullOr (types.listOf types.str);
+                          default = null;
+                          description = "Regular expression patterns to exclude when resetting scores (case-insensitive).";
+                        };
                       };
                     }
                   );
@@ -182,14 +237,15 @@ let
                         };
 
                         until_quality = mkOption {
-                          type = types.str;
+                          type = types.nullOr types.str;
+                          default = null;
                           description = "Upgrade until this quality level is reached.";
                           example = "WEB 2160p";
                         };
 
                         until_score = mkOption {
-                          type = types.int;
-                          default = 10000;
+                          type = types.nullOr types.int;
+                          default = null;
                           description = "Upgrade until this custom format score is reached.";
                         };
                       };
@@ -200,38 +256,57 @@ let
                 };
 
                 min_format_score = mkOption {
-                  type = types.int;
-                  default = 0;
-                  description = "Minimum custom format score required.";
+                  type = types.nullOr types.int;
+                  default = null;
+                  description = "Minimum custom format score required to download a release.";
+                };
+
+                min_upgrade_format_score = mkOption {
+                  type = types.nullOr types.int;
+                  default = null;
+                  description = ''
+                    Minimum custom format score required to upgrade an already-downloaded
+                    release.
+                  '';
                 };
 
                 quality_sort = mkOption {
-                  type = types.enum [
-                    "top"
-                    "bottom"
-                  ];
-                  default = "top";
+                  type = types.nullOr (
+                    types.enum [
+                      "top"
+                      "bottom"
+                    ]
+                  );
+                  default = null;
                   description = "Quality sort order (top = highest quality first).";
                 };
 
                 qualities = mkOption {
-                  type = types.listOf (
-                    types.submodule {
-                      options = {
-                        name = mkOption {
-                          type = types.str;
-                          description = "Quality name (e.g., 'WEB 2160p', 'Bluray-1080p').";
-                        };
+                  type = types.nullOr (
+                    types.listOf (
+                      types.submodule {
+                        options = {
+                          name = mkOption {
+                            type = types.str;
+                            description = "Quality name (e.g., 'WEB 2160p', 'Bluray-1080p').";
+                          };
 
-                        qualities = mkOption {
-                          type = types.nullOr (types.listOf types.str);
-                          default = null;
-                          description = "Optional list of specific quality variants (e.g., `['WEBDL-2160p', 'WEBRip-2160p']`).";
+                          enabled = mkOption {
+                            type = types.bool;
+                            default = true;
+                            description = "Whether this quality is enabled in the profile.";
+                          };
+
+                          qualities = mkOption {
+                            type = types.nullOr (types.listOf types.str);
+                            default = null;
+                            description = "Optional list of specific quality variants (e.g., `['WEBDL-2160p', 'WEBRip-2160p']`).";
+                          };
                         };
-                      };
-                    }
+                      }
+                    )
                   );
-                  default = [ ];
+                  default = null;
                   description = "Ordered list of qualities in the profile (from highest to lowest priority).";
                 };
               };
@@ -241,8 +316,10 @@ let
           description = ''
             List of quality profiles to create or update.
 
-            Redefining qualities introduced by `nixflix.recyclarr.config.<type>.<instance>.include`
-            will entirely replace the original.
+            Prefer setting `trash_id` to use a guide-backed profile — qualities, custom
+            formats, scores, and language will be configured automatically from the
+            TRaSH Guides. For user-defined profiles, set `name` along with `qualities`
+            and other fields.
           '';
         };
 
@@ -261,9 +338,21 @@ let
                   type = types.listOf (
                     types.submodule {
                       options = {
+                        trash_id = mkOption {
+                          type = types.nullOr types.str;
+                          default = null;
+                          description = ''
+                            Guide-backed quality profile trash_id to assign scores to.
+                            Either `trash_id` or `name` must be specified.
+                          '';
+                        };
                         name = mkOption {
-                          type = types.str;
-                          description = "Name of the quality profile to assign scores to";
+                          type = types.nullOr types.str;
+                          default = null;
+                          description = ''
+                            Name of the quality profile to assign scores to.
+                            Either `trash_id` or `name` must be specified.
+                          '';
                         };
                         score = mkOption {
                           type = types.nullOr types.int;
@@ -283,22 +372,132 @@ let
           description = "List of custom format configurations from TRaSH guides";
         };
 
+        custom_format_groups = mkOption {
+          type = types.nullOr (
+            types.submodule {
+              options = {
+                skip = mkOption {
+                  type = types.nullOr (types.listOf types.str);
+                  default = null;
+                  description = ''
+                    Trash IDs of custom format groups to skip. Use this to opt out of
+                    auto-synced default groups.
+                  '';
+                };
+
+                add = mkOption {
+                  type = types.listOf (
+                    types.submodule {
+                      options = {
+                        trash_id = mkOption {
+                          type = types.str;
+                          description = "Trash ID of the custom format group to add.";
+                        };
+
+                        assign_scores_to = mkOption {
+                          type = types.nullOr (
+                            types.listOf (
+                              types.submodule {
+                                options = {
+                                  trash_id = mkOption {
+                                    type = types.nullOr types.str;
+                                    default = null;
+                                    description = "Guide-backed quality profile trash_id to assign scores to.";
+                                  };
+                                  name = mkOption {
+                                    type = types.nullOr types.str;
+                                    default = null;
+                                    description = "Name of the quality profile to assign scores to.";
+                                  };
+                                };
+                              }
+                            )
+                          );
+                          default = null;
+                          description = ''
+                            Quality profiles to assign scores to. If omitted, scores are
+                            assigned to all guide-backed profiles.
+                          '';
+                        };
+
+                        select_all = mkOption {
+                          type = types.nullOr types.bool;
+                          default = null;
+                          description = ''
+                            Include all custom formats in the group regardless of their
+                            default status. Mutually exclusive with `select`.
+                          '';
+                        };
+
+                        select = mkOption {
+                          type = types.nullOr (types.listOf types.str);
+                          default = null;
+                          description = ''
+                            Non-default custom formats to additionally include. Required CFs
+                            are always included. Mutually exclusive with `select_all`.
+                          '';
+                        };
+
+                        exclude = mkOption {
+                          type = types.nullOr (types.listOf types.str);
+                          default = null;
+                          description = ''
+                            Default custom formats to exclude from the group. Required CFs
+                            cannot be excluded.
+                          '';
+                        };
+                      };
+                    }
+                  );
+                  default = [ ];
+                  description = ''
+                    Custom format groups to explicitly add. Use this for non-default groups
+                    or groups not auto-matched to your profiles.
+                  '';
+                };
+              };
+            }
+          );
+          default = null;
+          description = ''
+            Custom format groups from the TRaSH Guides. Groups marked `default: true` in
+            the guide are automatically synced when using guide-backed quality profiles.
+            Use `skip` to opt out of defaults or `add` to opt in to non-default groups.
+          '';
+        };
+
         include = mkOption {
           type = types.listOf (
             types.submodule {
-              options.template = mkOption {
-                type = types.str;
-                description = "Name of the [TRaSH template](https://github.com/recyclarr/config-templates/tree/master/${instanceType}/includes) to include.";
-                example =
-                  if instanceType == "radarr" then
-                    "radarr-quality-profile-remux-web-2160p"
-                  else
-                    "sonarr-v4-quality-profile-web-2160p-alternative";
+              options = {
+                template = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    ID of a config include template from the Recyclarr
+                    [config-templates repository](https://github.com/recyclarr/config-templates)
+                    (or a local replacement). As of Recyclarr v8 the official repository no
+                    longer ships any include templates, so this only works with a custom
+                    resource provider or user-supplied local includes.
+                  '';
+                };
+
+                config = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    Path to a local YAML file (relative paths are resolved under the
+                    Recyclarr `includes` directory) to merge into this instance's config.
+                  '';
+                };
               };
             }
           );
           default = [ ];
-          description = "List of TRaSH guide templates to include";
+          description = ''
+            List of includes to merge into this instance. Each entry must set exactly one
+            of `template` or `config`.
+          '';
         };
       };
     };
@@ -331,34 +530,19 @@ in
           api_key._secret = "/run/credentials/recyclarr.service/sonarr-api_key";
           quality_definition.type = "series";
           quality_profiles = [{
-            name = "WEB-2160p";
-            upgrade = {
-              allowed = true;
-              until_quality = "WEB 2160p";
-              until_score = 10000;
-            };
-            min_format_score = 0;
-            quality_sort = "top";
-            qualities = [
-              { name = "WEB 2160p"; qualities = ["WEBDL-2160p" "WEBRip-2160p"]; }
-              { name = "WEB 1080p"; qualities = ["WEBDL-1080p" "WEBRip-1080p"]; }
-            ];
+            trash_id = "dfa5eaae7894077ad6449169b6eb03e0"; # WEB-2160p (Alternative)
+            reset_unmatched_scores.enabled = true;
           }];
-          custom_formats = [{
-            trash_ids = [
-              "85c61753df5da1fb2aab6f2a47426b09" # BR-DISK
-              "9c11cd3f07101cdba90a2d81cf0e56b4" # LQ
-            ];
-            assign_scores_to = [{ name = "WEB-2160p"; }];
+          custom_format_groups.add = [{
+            trash_id = "e3f37512790f00d0e89e54fe5e790d1c"; # [Required] Golden Rule UHD
+            select = [ "9b64dff695c2115facf1b6ea59c9bd07" ]; # x265 (no HDR/DV)
           }];
-          include = [
-            { template = "sonarr-v4-quality-profile-web-2160p-alternative"; }
-          ];
         };
         radarr.radarr_main = {
           base_url = "http://127.0.0.1:7878";
           api_key._secret = "/run/credentials/recyclarr.service/radarr-api_key";
           quality_definition.type = "movie";
+          media_management.propers_and_repacks = "do_not_prefer";
         };
       }
     '';
@@ -374,8 +558,10 @@ in
 
       Defaults are `sonarr.sonarr`, `sonarr.sonarr_anime`, and `radarr.radarr`.
 
-      Each instance supports quality profiles, custom formats from TRaSH guides,
-      media naming configuration, and template includes.
+      Each instance supports guide-backed quality profiles (via `trash_id`) or
+      user-defined ones (via `name`), custom formats and custom format groups
+      from TRaSH guides, media naming, media management (e.g. Propers and
+      Repacks handling), and template/file includes.
 
       [Config Reference](https://recyclarr.dev/wiki/yaml/config-reference/)
     '';

--- a/modules/recyclarr/config-option.nix
+++ b/modules/recyclarr/config-option.nix
@@ -288,7 +288,8 @@ let
                         options = {
                           name = mkOption {
                             type = types.str;
-                            description = "Quality name (e.g., 'WEB 2160p', 'Bluray-1080p').";
+                            description = "Quality name.";
+                            example = "WEB 2160p";
                           };
 
                           enabled = mkOption {
@@ -300,7 +301,11 @@ let
                           qualities = mkOption {
                             type = types.nullOr (types.listOf types.str);
                             default = null;
-                            description = "Optional list of specific quality variants (e.g., `['WEBDL-2160p', 'WEBRip-2160p']`).";
+                            description = "Optional list of specific quality variants.";
+                            example = [
+                              "WEBDL-2160p"
+                              "WEBRip-2160p"
+                            ];
                           };
                         };
                       }

--- a/modules/recyclarr/default.nix
+++ b/modules/recyclarr/default.nix
@@ -137,6 +137,57 @@ in
   };
 
   config = mkIf (config.nixflix.enable && cfg.enable) {
+    assertions =
+      let
+        cfg' = cfg.config;
+        instances = optionals (cfg' != null) (
+          concatMap (svc: mapAttrsToList (name: inst: { inherit svc name inst; }) (cfg'.${svc} or { })) [
+            "sonarr"
+            "radarr"
+          ]
+        );
+        set = v: v != null;
+        xor = a: b: set a != set b;
+      in
+      concatMap (
+        {
+          svc,
+          name,
+          inst,
+        }:
+        let
+          p = "nixflix.recyclarr.config.${svc}.${name}";
+        in
+        map (qp: {
+          assertion = set (qp.name or null) || set (qp.trash_id or null);
+          message = "${p}.quality_profiles: entry must set at least one of `name` or `trash_id`";
+        }) (inst.quality_profiles or [ ])
+        ++ map (inc: {
+          assertion = xor (inc.template or null) (inc.config or null);
+          message = "${p}.include: entry must set exactly one of `template` or `config`";
+        }) (inst.include or [ ])
+        ++ concatMap (
+          cf:
+          map (ref: {
+            assertion = xor (ref.name or null) (ref.trash_id or null);
+            message = "${p}.custom_formats.assign_scores_to: entry must set exactly one of `name` or `trash_id`";
+          }) (cf.assign_scores_to or [ ])
+        ) (inst.custom_formats or [ ])
+        ++ concatMap (
+          g:
+          [
+            {
+              assertion = !((g.select_all or false) && set (g.select or null));
+              message = "${p}.custom_format_groups.add: `select_all` and `select` are mutually exclusive";
+            }
+          ]
+          ++ map (ref: {
+            assertion = xor (ref.name or null) (ref.trash_id or null);
+            message = "${p}.custom_format_groups.add.assign_scores_to: entry must set exactly one of `name` or `trash_id`";
+          }) (g.assign_scores_to or [ ])
+        ) ((inst.custom_format_groups or { }).add or [ ])
+      ) instances;
+
     users.users.${cfg.user} = optionalAttrs (config.nixflix.globals.uids ? ${cfg.user}) {
       uid = mkForce config.nixflix.globals.uids.${cfg.user};
     };

--- a/modules/recyclarr/default.nix
+++ b/modules/recyclarr/default.nix
@@ -68,13 +68,14 @@ in
         This option selects profiles that prioritize acquisition over quality.
         Lower quality hits that meet TRaSH standards will be accepted and grabbed.
 
-        - 4k creates a profile named "SQP-1 (2160p)"
-        - 1080p creates a profile named "SQP-1 (1080p)"
+        - 4k creates a profile named "[SQP] SQP-1 (2160p)"
+        - 1080p creates a profile named "[SQP] SQP-1 (1080p)"
 
         If you want Seerr to use these, you'll have to configure them manually.
 
         Complex configurations can be manually applied using `nixflix.recyclarr.config.radarr.radarr`.
-        If you do, you need to set `nixflix.recyclarr.config.radarr.radarr.include = mkForce [];`.
+        If you do, you need to set
+        `nixflix.recyclarr.config.radarr.radarr.quality_profiles = mkForce [];`.
       '';
     };
 
@@ -92,13 +93,14 @@ in
         This option selects profiles that prioritize acquisition over quality.
         Lower quality hits that meet TRaSH standards will be accepted and grabbed.
 
-        - 4k creates a quality profile named "WEB-2160p"
-        - 1080p creates a quality profile named "WEB-1080p"
+        - 4k creates a quality profile named "WEB-2160p (Alternative)"
+        - 1080p creates a quality profile named "WEB-1080p (Alternative)"
 
         If you want Seerr to use these, you'll have to configure them manually.
 
         Complex configurations can be manually applied using `nixflix.recyclarr.config.sonarr.sonarr`.
-        If you do, you need to set `nixflix.recyclarr.config.sonarr.sonarr.include = mkForce [];`.
+        If you do, you need to set
+        `nixflix.recyclarr.config.sonarr.sonarr.quality_profiles = mkForce [];`.
       '';
     };
 
@@ -115,15 +117,17 @@ in
       managedProfiles = mkOption {
         type = types.listOf types.str;
         default =
-          optional (cfg.radarrQuality == "4K") "SQP-1 (2160p)"
-          ++ optional (cfg.radarrQuality == "1080p") "SQP-1 (1080p)"
-          ++ optional (cfg.sonarrQuality == "4K") "WEB-2160p"
-          ++ optional (cfg.sonarrQuality == "1080p") "WEB-1080p";
+          optional (cfg.radarrQuality == "4K") "[SQP] SQP-1 (2160p)"
+          ++ optional (cfg.radarrQuality == "1080p") "[SQP] SQP-1 (1080p)"
+          ++ optional (cfg.sonarrQuality == "4K") "WEB-2160p (Alternative)"
+          ++ optional (cfg.sonarrQuality == "1080p") "WEB-1080p (Alternative)"
+          ++ optional config.nixflix.sonarr-anime.enable "[Anime] Remux-1080p";
         defaultText = literalExpression ''
-          optional (cfg.radarrQuality == "4K") "SQP-1 (2160p)"
-          ++ optional (cfg.radarrQuality == "1080p") "SQP-1 (1080p)"
-          ++ optional (cfg.sonarrQuality == "4K") "WEB-2160p"
-          ++ optional (cfg.sonarrQuality == "1080p") "WEB-1080p";
+          optional (cfg.radarrQuality == "4K") "[SQP] SQP-1 (2160p)"
+          ++ optional (cfg.radarrQuality == "1080p") "[SQP] SQP-1 (1080p)"
+          ++ optional (cfg.sonarrQuality == "4K") "WEB-2160p (Alternative)"
+          ++ optional (cfg.sonarrQuality == "1080p") "WEB-1080p (Alternative)"
+          ++ optional config.nixflix.sonarr-anime.enable "[Anime] Remux-1080p";
         '';
         example = [ "My Custom Profile" ];
         description = ''

--- a/modules/recyclarr/radarr.nix
+++ b/modules/recyclarr/radarr.nix
@@ -16,7 +16,7 @@ in
     delete_old_custom_formats = lib.mkDefault true;
 
     quality_definition = {
-      type = lib.mkDefault "movie";
+      type = lib.mkDefault "sqp-streaming";
     };
 
     media_naming = {
@@ -27,22 +27,15 @@ in
       };
     };
 
-    include = lib.mkDefault (
-      [
-        { template = "radarr-quality-definition-sqp-streaming"; }
-      ]
-      ++ (
-        if cfg.radarrQuality == "4K" then
-          [
-            { template = "radarr-quality-profile-sqp-1-2160p-default"; }
-            { template = "radarr-custom-formats-sqp-1-2160p"; }
-          ]
-        else
-          [
-            { template = "radarr-quality-profile-sqp-1-1080p"; }
-            { template = "radarr-custom-formats-sqp-1-1080p"; }
-          ]
-      )
-    );
+    quality_profiles = lib.mkDefault [
+      {
+        trash_id =
+          if cfg.radarrQuality == "4K" then
+            "5128baeb2b081b72126bc8482b2a86a0" # [SQP] SQP-1 (2160p)
+          else
+            "0896c29d74de619df168d23b98104b22"; # [SQP] SQP-1 (1080p)
+        reset_unmatched_scores.enabled = true;
+      }
+    ];
   };
 }

--- a/modules/recyclarr/radarr.nix
+++ b/modules/recyclarr/radarr.nix
@@ -14,7 +14,6 @@ in
     base_url = lib.mkDefault "http://127.0.0.1:${toString config.nixflix.radarr.config.hostConfig.port}${toString config.nixflix.radarr.config.hostConfig.urlBase}";
     api_key = lib.mkDefault config.nixflix.radarr.config.apiKey;
     delete_old_custom_formats = lib.mkDefault true;
-    replace_existing_custom_formats = lib.mkDefault true;
 
     quality_definition = {
       type = lib.mkDefault "movie";

--- a/modules/recyclarr/sonarr-anime.nix
+++ b/modules/recyclarr/sonarr-anime.nix
@@ -11,7 +11,6 @@
     base_url = lib.mkDefault "http://127.0.0.1:${toString config.nixflix.sonarr-anime.config.hostConfig.port}${toString config.nixflix.sonarr-anime.config.hostConfig.urlBase}";
     api_key = lib.mkDefault config.nixflix.sonarr-anime.config.apiKey;
     delete_old_custom_formats = lib.mkDefault true;
-    replace_existing_custom_formats = lib.mkDefault true;
 
     quality_definition = {
       type = lib.mkDefault "anime";

--- a/modules/recyclarr/sonarr-anime.nix
+++ b/modules/recyclarr/sonarr-anime.nix
@@ -27,41 +27,10 @@
       };
     };
 
-    include = lib.mkDefault [
-      { template = "sonarr-quality-definition-anime"; }
-      { template = "sonarr-v4-quality-profile-anime"; }
-      { template = "sonarr-v4-custom-formats-anime"; }
-    ];
-
-    custom_formats = lib.mkDefault [
+    quality_profiles = lib.mkDefault [
       {
-        trash_ids = [ "026d5aadd1a6b4e550b134cb6c72b3ca" ]; # Uncensored
-        assign_scores_to = [
-          {
-            name = "Remux-1080p - Anime";
-            score = 0;
-          }
-        ];
-      }
-
-      {
-        trash_ids = [ "026d5aadd1a6b4e550b134cb6c72b3ca" ]; # 10bit
-        assign_scores_to = [
-          {
-            name = "Remux-1080p - Anime";
-            score = 0;
-          }
-        ];
-      }
-
-      {
-        trash_ids = [ "026d5aadd1a6b4e550b134cb6c72b3ca" ]; # Anime Dual Audio
-        assign_scores_to = [
-          {
-            name = "Remux-1080p - Anime";
-            score = 0;
-          }
-        ];
+        trash_id = "20e0fc959f1f1704bed501f23bdae76f"; # [Anime] Remux-1080p
+        reset_unmatched_scores.enabled = true;
       }
     ];
   };

--- a/modules/recyclarr/sonarr.nix
+++ b/modules/recyclarr/sonarr.nix
@@ -30,22 +30,15 @@ in
       };
     };
 
-    include = lib.mkDefault (
-      [
-        { template = "sonarr-quality-definition-series"; }
-      ]
-      ++ (
-        if cfg.sonarrQuality == "4K" then
-          [
-            { template = "sonarr-v4-quality-profile-web-2160p-alternative"; }
-            { template = "sonarr-v4-custom-formats-web-2160p"; }
-          ]
-        else
-          [
-            { template = "sonarr-v4-quality-profile-web-1080p-alternative"; }
-            { template = "sonarr-v4-custom-formats-web-1080p"; }
-          ]
-      )
-    );
+    quality_profiles = lib.mkDefault [
+      {
+        trash_id =
+          if cfg.sonarrQuality == "4K" then
+            "dfa5eaae7894077ad6449169b6eb03e0" # WEB-2160p (Alternative)
+          else
+            "9d142234e45d6143785ac55f5a9e8dc9"; # WEB-1080p (Alternative)
+        reset_unmatched_scores.enabled = true;
+      }
+    ];
   };
 }

--- a/modules/recyclarr/sonarr.nix
+++ b/modules/recyclarr/sonarr.nix
@@ -14,7 +14,6 @@ in
     base_url = lib.mkDefault "http://127.0.0.1:${toString config.nixflix.sonarr.config.hostConfig.port}${toString config.nixflix.sonarr.config.hostConfig.urlBase}";
     api_key = lib.mkDefault config.nixflix.sonarr.config.apiKey;
     delete_old_custom_formats = lib.mkDefault true;
-    replace_existing_custom_formats = lib.mkDefault true;
 
     quality_definition = {
       type = lib.mkDefault "series";

--- a/tests/vm-tests/recyclarr-basic.nix
+++ b/tests/vm-tests/recyclarr-basic.nix
@@ -154,9 +154,9 @@ pkgsUnfree.testers.runNixOSTest {
     )
     radarr_profiles_list = json.loads(radarr_profiles)
 
-    radarr_profile_names = [p['name'] for p in radarr_profiles_list]
-    assert "SQP-1 (1080p)" in radarr_profile_names, \
-        f"Expected 'UHD Bluray + WEB' profile from recyclarr in Radarr, found: {radarr_profile_names}"
+    radarr_profile_names = {p['name'] for p in radarr_profiles_list}
+    assert radarr_profile_names == {"[SQP] SQP-1 (1080p)"}, \
+        f"Expected only '[SQP] SQP-1 (1080p)' in Radarr after cleanup, found: {radarr_profile_names}"
 
     # Check that quality profiles were created by recyclarr for Sonarr
     sonarr_profiles = machine.succeed(
@@ -165,12 +165,9 @@ pkgsUnfree.testers.runNixOSTest {
     )
     sonarr_profiles_list = json.loads(sonarr_profiles)
 
-    sonarr_profile_names = [p['name'] for p in sonarr_profiles_list]
-    # Sonarr should have both normal and anime profiles when sonarr-anime is enabled
-    assert "WEB-1080p" in sonarr_profile_names, \
-        f"Expected 'WEB-1080p' profile from recyclarr in Sonarr, found: {sonarr_profile_names}"
-    assert len(sonarr_profiles_list) > 1, \
-        f"Expected multiple quality profiles in Sonarr, found: {len(sonarr_profiles_list)}"
+    sonarr_profile_names = {p['name'] for p in sonarr_profiles_list}
+    assert sonarr_profile_names == {"WEB-1080p (Alternative)"}, \
+        f"Expected only 'WEB-1080p (Alternative)' in Sonarr after cleanup, found: {sonarr_profile_names}"
 
     # Check that quality profiles were created by recyclarr for Sonarr-Anime
     sonarr_anime_profiles = machine.succeed(
@@ -179,9 +176,9 @@ pkgsUnfree.testers.runNixOSTest {
     )
     sonarr_anime_profiles_list = json.loads(sonarr_anime_profiles)
 
-    sonarr_anime_profile_names = [p['name'] for p in sonarr_anime_profiles_list]
-    assert "Remux-1080p - Anime" in sonarr_anime_profile_names, \
-        f"Expected 'Remux-1080p - Anime' profile from recyclarr in Sonarr-Anime, found: {sonarr_anime_profile_names}"
+    sonarr_anime_profile_names = {p['name'] for p in sonarr_anime_profiles_list}
+    assert sonarr_anime_profile_names == {"[Anime] Remux-1080p"}, \
+        f"Expected only '[Anime] Remux-1080p' in Sonarr-Anime after cleanup, found: {sonarr_anime_profile_names}"
 
     # Wait for cleanup-profiles service to complete
     machine.wait_until_succeeds(


### PR DESCRIPTION
Fixes #119

- Remove `replace_existing_custom_formats` (dropped in recyclarr v8)
- Add v8 schema fields: `trash_id`/`score_set`/`min_upgrade_format_score` on quality profiles, `custom_format_groups`, `media_management`, `sqp-streaming`/`sqp-uhd` quality definition types
- Add eval-time assertions for v8 cross-field rules (`name`/`trash_id` exclusivity, `select_all`/`select` mutual exclusion)
- Replace removed include templates with guide-backed `trash_id` profiles
- Update `managedProfiles` defaults to v8 profile names
- Fix cleanup script skipping instances where `managedProfiles[0]` doesn't exist (iterate list instead)
- Tighten VM test to assert exact post-cleanup profile sets
- Bump nixpkgs for recyclarr 8.5.1

Tested on a live machine with Sonarr+Radarr.

## Upgrading

If you use `nixflix.inputs.nixpkgs.follows = "nixpkgs";`, then you will need to upgrade your `nixpkgs` flake input. This can be done with `nix flake update nixpkgs`.