### PR TITLE
feat: add Caddy as alternative reverse proxy to nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Caddy as alternative reverse proxy to nginx via `nixflix.caddy` ([#163](https://github.com/kiriwalawren/nixflix/pull/163))
+- Per-service reverse proxy opt-out via `reverseProxy.expose` ([#163](https://github.com/kiriwalawren/nixflix/pull/163))
 - Generic WireGuard VPN support via `nixflix.vpn` ([#164](https://github.com/kiriwalawren/nixflix/pull/164))
 - Jellyfin Plugin management ([#156](https://github.com/kiriwalawren/nixflix/pull/156)).
 - Mullvad first-class Tailscale coexistence option (`nixflix.mullvad.tailscale`) ([#141](https://github.com/kiriwalawren/nixflix/pull/141)).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Nixflix is:
 - **WireGuard VPN Integration**: Built-in support for Wireguard VPN with kill switch and custom DNS
 - **Flexible Directory Management**: Configurable media and state directories with automatic setup
 - **Service Dependencies**: Configure custom systemd service dependencies
-- **Optional Nginx Reverse Proxy**: Configurable nginx integration for all services
+- **Reverse Proxy Support**: Configurable nginx or Caddy integration for all services, with per-service opt-out
 - **Unified Theming**: All supported services can be themed to look the same, powered by [theme.park](https://docs.theme-park.dev/)
 - [**TRaSH Guides**](https://trash-guides.info): Default configuration follows TRaSH guidelines
 
@@ -83,7 +83,7 @@ All Arr services (Sonarr, Radarr, Lidarr, Prowlarr) support:
 
 - API-based configuration
 - PostgreSQL integration
-- Nginx reverse proxy
+- Reverse proxy (nginx or Caddy)
 - Automatic directory creation
 - Root folder management
 - Custom media directories

--- a/docs/examples/basic-setup.md
+++ b/docs/examples/basic-setup.md
@@ -44,10 +44,15 @@ This example shows a working media server configuration based on a real producti
       name = "overseerr";
     };
 
+    # Reverse proxy (choose nginx or caddy, not both)
     nginx = {
       enable = true;
-      addHostsEntries = true; # Disable this is you have your own DNS configuration
+      addHostsEntries = true; # Disable this if you have your own DNS configuration
     };
+    # caddy = {
+    #   enable = true;
+    #   addHostsEntries = true;
+    # };
 
     postgres.enable = true;
 
@@ -183,7 +188,7 @@ This example shows a working media server configuration based on a real producti
 ### Infrastructure
 
 - **PostgreSQL** - Database backend for better performance
-- **Nginx** - Reverse proxy for all services
+- **Nginx** (or **Caddy**) - Reverse proxy for all services
 - **theme.park** - UI theming (set to "plex" theme)
 
 ### Automatic Integration
@@ -239,7 +244,7 @@ This example shows a working media server configuration based on a real producti
 
 ## Service Access
 
-Via nginx reverse proxy:
+Via reverse proxy (nginx or Caddy):
 
 - Sonarr: http://sonarr.nixflix
 - Sonarr Anime: http://sonarr-anime.nixflix

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -68,7 +68,10 @@ Here's a minimal configuration to get started:
     mediaDir = "/data/media";
     stateDir = "/data/.state";
 
+    # Reverse proxy: choose one
     nginx.enable = true;
+    # caddy.enable = true;
+
     postgres.enable = true;
 
     sonarr = {

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -49,6 +49,8 @@ Each option is documented with:
 
 ### Infrastructure
 
+- [Nginx](nginx/index.md) - Nginx reverse proxy
+- [Caddy](caddy/index.md) - Caddy reverse proxy
 - [VPN](vpn/index.md) - WireGuard VPN configuration
 - [PostgreSQL](postgres/index.md) - Database configuration
 - [Recyclarr](recyclarr/index.md) - TRaSH guides automation

--- a/lib/mkVirtualHosts.nix
+++ b/lib/mkVirtualHosts.nix
@@ -13,20 +13,27 @@ let
   # automatically enabling HTTPS. "tls off" is not valid Caddyfile syntax.
   caddyHostPrefix = if !tls.enable then "http://" else "";
 
-  # --- Shared theme.park URL builder ---
+  # --- Shared theme.park helpers ---
   themeParkUrl = service: "https://theme-park.dev/css/base/${service}/${cfg.theme.name}.css";
+
+  # Services that inject the stylesheet into <head> instead of <body>
+  themeParkTags = {
+    overseerr = "</head>";
+    sabnzbd = "</head>";
+  };
 
   mkNginxVirtualHost =
     {
       port,
       themeParkService ? null,
-      themeParkTag ? "</body>",
       extraConfig ? "",
       stripHeaders ? [ ],
       websocketUpgrade ? false,
       disableBuffering ? false,
     }:
     let
+      themeParkTag =
+        if themeParkService == null then "</body>" else themeParkTags.${themeParkService} or "</body>";
       themeConfig = lib.optionalString (themeParkService != null && cfg.theme.enable) ''
         proxy_set_header Accept-Encoding "";
         sub_filter '${themeParkTag}' '<link rel="stylesheet" type="text/css" href="${themeParkUrl themeParkService}">${themeParkTag}';
@@ -63,11 +70,14 @@ let
     {
       port,
       themeParkService ? null,
-      themeParkTag ? "</body>",
       extraConfig ? "",
       stripHeaders ? [ ],
       disableBuffering ? false,
     }:
+    let
+      themeParkTag =
+        if themeParkService == null then "</body>" else themeParkTags.${themeParkService} or "</body>";
+    in
     lib.mkIf cfg.caddy.enable {
       extraConfig = ''
         ${tlsDirective}
@@ -100,7 +110,6 @@ in
       expose,
       port,
       themeParkService ? null,
-      themeParkTag ? "</body>",
       extraConfig ? "",
       stripHeaders ? [ ],
       websocketUpgrade ? false,
@@ -111,7 +120,6 @@ in
         inherit
           port
           themeParkService
-          themeParkTag
           extraConfig
           stripHeaders
           disableBuffering

--- a/lib/mkVirtualHosts.nix
+++ b/lib/mkVirtualHosts.nix
@@ -119,9 +119,9 @@ in
       };
     in
     {
-      services.nginx.virtualHosts.${hostname} = lib.mkIf expose (mkNginxVirtualHost (
-        proxyArgs // { inherit websocketUpgrade; }
-      ));
+      services.nginx.virtualHosts.${hostname} = lib.mkIf expose (
+        mkNginxVirtualHost (proxyArgs // { inherit websocketUpgrade; })
+      );
 
       services.caddy.virtualHosts."${caddyHostPrefix}${hostname}" = lib.mkIf expose (
         mkCaddyVirtualHost proxyArgs

--- a/lib/mkVirtualHosts.nix
+++ b/lib/mkVirtualHosts.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  config,
+}:
+let
+  cfg = config.nixflix;
+
+  # --- Caddy helpers ---
+  inherit (cfg.caddy) tls;
+  tlsDirective = if tls.enable && tls.internal then "tls internal" else "";
+
+  # When TLS is disabled, prefix with http:// to prevent Caddy from
+  # automatically enabling HTTPS. "tls off" is not valid Caddyfile syntax.
+  caddyHostPrefix = if !tls.enable then "http://" else "";
+
+  # --- Shared theme.park URL builder ---
+  themeParkUrl = service: "https://theme-park.dev/css/base/${service}/${cfg.theme.name}.css";
+
+  mkNginxVirtualHost =
+    {
+      port,
+      themeParkService ? null,
+      themeParkTag ? "</body>",
+      extraConfig ? "",
+      stripHeaders ? [ ],
+      websocketUpgrade ? false,
+      disableBuffering ? false,
+    }:
+    let
+      themeConfig = lib.optionalString (themeParkService != null && cfg.theme.enable) ''
+        proxy_set_header Accept-Encoding "";
+        sub_filter '${themeParkTag}' '<link rel="stylesheet" type="text/css" href="${themeParkUrl themeParkService}">${themeParkTag}';
+        sub_filter_once on;
+      '';
+      hideHeaders = lib.concatMapStringsSep "\n" (h: ''proxy_hide_header "${h}";'') stripHeaders;
+      wsConfig = lib.optionalString websocketUpgrade ''
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+      '';
+      bufferingConfig = lib.optionalString disableBuffering ''
+        proxy_buffering off;
+      '';
+    in
+    lib.mkIf cfg.nginx.enable {
+      inherit (cfg.nginx) forceSSL;
+      useACMEHost = if cfg.nginx.enableACME then cfg.nginx.domain else null;
+
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:${toString port}";
+        recommendedProxySettings = true;
+        extraConfig = ''
+          proxy_redirect off;
+          ${wsConfig}
+          ${bufferingConfig}
+          ${hideHeaders}
+          ${themeConfig}
+          ${extraConfig}
+        '';
+      };
+    };
+
+  mkCaddyVirtualHost =
+    {
+      port,
+      themeParkService ? null,
+      themeParkTag ? "</body>",
+      extraConfig ? "",
+      stripHeaders ? [ ],
+      disableBuffering ? false,
+    }:
+    lib.mkIf cfg.caddy.enable {
+      extraConfig = ''
+        ${tlsDirective}
+
+        reverse_proxy http://127.0.0.1:${toString port} ${lib.optionalString disableBuffering ''
+          {
+            flush_interval -1
+          }
+        ''}
+
+        ${lib.concatMapStringsSep "\n" (h: "header_down -${h}") stripHeaders}
+
+        ${lib.optionalString (themeParkService != null && cfg.theme.enable) ''
+          replace {
+            ${themeParkTag} "<link rel=\"stylesheet\" type=\"text/css\" href=\"${themeParkUrl themeParkService}\">${themeParkTag}"
+          }
+          header_up -Accept-Encoding
+        ''}
+
+        ${extraConfig}
+      '';
+    };
+in
+{
+  ## Returns a NixOS config fragment with nginx, caddy, and hosts entries
+  ## for a single reverse-proxied service.
+  mkVirtualHost =
+    {
+      hostname,
+      expose,
+      port,
+      themeParkService ? null,
+      themeParkTag ? "</body>",
+      extraConfig ? "",
+      stripHeaders ? [ ],
+      websocketUpgrade ? false,
+      disableBuffering ? false,
+    }:
+    let
+      proxyArgs = {
+        inherit
+          port
+          themeParkService
+          themeParkTag
+          extraConfig
+          stripHeaders
+          disableBuffering
+          ;
+      };
+    in
+    {
+      services.nginx.virtualHosts.${hostname} = lib.mkIf expose (mkNginxVirtualHost (
+        proxyArgs // { inherit websocketUpgrade; }
+      ));
+
+      services.caddy.virtualHosts."${caddyHostPrefix}${hostname}" = lib.mkIf expose (
+        mkCaddyVirtualHost proxyArgs
+      );
+
+      networking.hosts = lib.mkIf (
+        expose && cfg.reverseProxy.enable && cfg.reverseProxy.addHostsEntries
+      ) { "127.0.0.1" = [ hostname ]; };
+    };
+}

--- a/modules/arr-common/mkArrServiceModule.nix
+++ b/modules/arr-common/mkArrServiceModule.nix
@@ -8,6 +8,7 @@ serviceName:
 with lib;
 let
   secrets = import ../../lib/secrets { inherit lib; };
+  inherit (import ../../lib/mkVirtualHosts.nix { inherit lib config; }) mkVirtualHost;
   inherit (config.nixflix) globals;
   cfg = config.nixflix.${serviceName};
   stateDir = "${config.nixflix.stateDir}/${serviceName}";
@@ -33,7 +34,7 @@ let
   delayProfiles = import ./delayProfiles.nix { inherit lib pkgs serviceName; };
   capitalizedName = toUpper (substring 0 1 serviceName) + substring 1 (-1) serviceName;
   usesMediaDirs = !(elem serviceName [ "prowlarr" ]);
-  hostname = "${cfg.subdomain}.${config.nixflix.nginx.domain}";
+  hostname = "${cfg.subdomain}.${config.nixflix.reverseProxy.domain}";
 
   serviceBase = builtins.elemAt (splitString "-" serviceName) 0;
 
@@ -93,7 +94,15 @@ in
     subdomain = mkOption {
       type = types.str;
       default = serviceName;
-      description = "Subdomain prefix for nginx reverse proxy. Service accessible at `<subdomain>.<domain>`.";
+      description = "Subdomain prefix for reverse proxy. Service accessible at `<subdomain>.<domain>`.";
+    };
+
+    reverseProxy = {
+      expose = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to expose this service via the reverse proxy.";
+      };
     };
 
     settings = mkOption {
@@ -223,32 +232,38 @@ in
     };
   };
 
-  config = mkMerge [
-    (mkIf (config.nixflix.enable && cfg.enable) {
-      assertions = [
-        {
-          assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
-          message = "Cannot enable VPN routing for ${capitalizedName} (`config.nixflix.${serviceName}.vpn.enable = true`) when VPN is not enabled. Please set `nixflix.vpn.enable` = true.";
-        }
-        {
-          assertion =
-            (cfg.vpn.enable && config.nixflix.torrentClients.qbittorrent.enable)
-            -> config.nixflix.torrentClients.qbittorrent.vpn.enable;
-          message = "${capitalizedName} is VPN-confined but qBittorrent is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.torrentClients.qbittorrent.vpn.enable = true` or disable VPN for ${capitalizedName}.";
-        }
-        {
-          assertion =
-            (cfg.vpn.enable && config.nixflix.usenetClients.sabnzbd.enable)
-            -> config.nixflix.usenetClients.sabnzbd.vpn.enable;
-          message = "${capitalizedName} is VPN-confined but SABnzbd is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.usenetClients.sabnzbd.vpn.enable = true` or disable VPN for ${capitalizedName}.";
-        }
-        {
-          assertion =
-            (usesMediaDirs && cfg.vpn.enable && config.nixflix.prowlarr.enable)
-            -> config.nixflix.prowlarr.vpn.enable;
-          message = "${capitalizedName} is VPN-confined but Prowlarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.prowlarr.vpn.enable = true` or disable VPN for ${capitalizedName}.";
-        }
-      ];
+  config = mkIf (config.nixflix.enable && cfg.enable) (mkMerge [
+    (mkVirtualHost {
+      inherit hostname;
+      inherit (cfg.reverseProxy) expose;
+      inherit (cfg.config.hostConfig) port;
+      themeParkService = serviceBase;
+    })
+    {
+    assertions = [
+      {
+        assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
+        message = "Cannot enable VPN routing for ${capitalizedName} (`config.nixflix.${serviceName}.vpn.enable = true`) when VPN is not enabled. Please set `nixflix.vpn.enable` = true.";
+      }
+      {
+        assertion =
+          (cfg.vpn.enable && config.nixflix.torrentClients.qbittorrent.enable)
+          -> config.nixflix.torrentClients.qbittorrent.vpn.enable;
+        message = "${capitalizedName} is VPN-confined but qBittorrent is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.torrentClients.qbittorrent.vpn.enable = true` or disable VPN for ${capitalizedName}.";
+      }
+      {
+        assertion =
+          (cfg.vpn.enable && config.nixflix.usenetClients.sabnzbd.enable)
+          -> config.nixflix.usenetClients.sabnzbd.vpn.enable;
+        message = "${capitalizedName} is VPN-confined but SABnzbd is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.usenetClients.sabnzbd.vpn.enable = true` or disable VPN for ${capitalizedName}.";
+      }
+      {
+        assertion =
+          (usesMediaDirs && cfg.vpn.enable && config.nixflix.prowlarr.enable)
+          -> config.nixflix.prowlarr.vpn.enable;
+        message = "${capitalizedName} is VPN-confined but Prowlarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.prowlarr.vpn.enable = true` or disable VPN for ${capitalizedName}.";
+      }
+    ];
 
       nixflix.${serviceName} = {
         settings = {
@@ -278,50 +293,17 @@ in
         };
       };
 
-      services = {
-        postgresql = mkIf config.nixflix.postgres.enable {
-          ensureDatabases = [
-            cfg.settings.postgres.mainDb
-            cfg.settings.postgres.logDb
-          ];
-          ensureUsers = [
-            {
-              name = cfg.user;
-            }
-          ];
-        };
-
-        nginx.virtualHosts."${hostname}" = mkIf config.nixflix.nginx.enable {
-          inherit (config.nixflix.nginx) forceSSL;
-          useACMEHost = if config.nixflix.nginx.enableACME then config.nixflix.nginx.domain else null;
-
-          locations."/" =
-            let
-              themeParkUrl = "https://theme-park.dev/css/base/${serviceBase}/${config.nixflix.theme.name}.css";
-            in
-            {
-              proxyPass = "http://${cfg.config.hostConfig.bindAddress}:${builtins.toString cfg.config.hostConfig.port}";
-              recommendedProxySettings = true;
-              extraConfig = ''
-                proxy_redirect off;
-
-                ${
-                  if config.nixflix.theme.enable then
-                    ''
-                      proxy_set_header Accept-Encoding "";
-                      sub_filter '</body>' '<link rel="stylesheet" type="text/css" href="${themeParkUrl}"></body>';
-                      sub_filter_once on;
-                    ''
-                  else
-                    ""
-                }
-              '';
-            };
-        };
-      };
-
-      networking.hosts = mkIf (config.nixflix.nginx.enable && config.nixflix.nginx.addHostsEntries) {
-        "127.0.0.1" = [ hostname ];
+      # Removed: nginx.virtualHosts and networking.hosts — mkVirtualHost handles these
+      services.postgresql = mkIf config.nixflix.postgres.enable {
+        ensureDatabases = [
+          cfg.settings.postgres.mainDb
+          cfg.settings.postgres.logDb
+        ];
+        ensureUsers = [
+          {
+            name = cfg.user;
+          }
+        ];
       };
 
       users = {
@@ -420,6 +402,7 @@ in
           description = capitalizedName;
           environment = mkServarrSettingsEnvVars (toUpper serviceBase) cfg.settings;
 
+          # Added: mullvad-config.service dependency from caddy branch
           after = [
             "network.target"
             "nixflix-setup-dirs.service"
@@ -428,7 +411,8 @@ in
           ++ (optional (
             cfg.config.apiKey != null && cfg.config.hostConfig.password != null
           ) "${serviceName}-env.service")
-          ++ (optional config.nixflix.postgres.enable "postgresql-ready.target");
+          ++ (optional config.nixflix.postgres.enable "postgresql-ready.target")
+          ++ (optional config.nixflix.mullvad.enable "mullvad-config.service");
           requires = [
             "nixflix-setup-dirs.service"
           ]
@@ -437,7 +421,8 @@ in
             cfg.config.apiKey != null && cfg.config.hostConfig.password != null
           ) "${serviceName}-env.service")
           ++ (optional config.nixflix.postgres.enable "postgresql-ready.target");
-          wants = [ ];
+          # Changed: from empty list to mullvad wants
+          wants = optional config.nixflix.mullvad.enable "mullvad-config.service";
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = {
@@ -450,6 +435,18 @@ in
           }
           // optionalAttrs (cfg.config.apiKey != null && cfg.config.hostConfig.password != null) {
             EnvironmentFile = "/run/${serviceName}/env";
+          }
+          # Added: mullvad VPN bypass from caddy branch — wraps ExecStart
+          # with mullvad-exclude when mullvad is enabled but this service opts out
+          // optionalAttrs (config.nixflix.mullvad.enable && !cfg.vpn.enable) {
+            ExecStart = mkForce (
+              pkgs.writeShellScript "${serviceName}-vpn-bypass" ''
+                exec /run/wrappers/bin/mullvad-exclude ${getExe cfg.package} \
+                  -nobrowser -data='${stateDir}'
+              ''
+            );
+            AmbientCapabilities = "CAP_SYS_ADMIN";
+            Delegate = mkForce true;
           };
         };
       }
@@ -482,8 +479,9 @@ in
       // optionalAttrs (usesMediaDirs && cfg.config.apiKey != null) {
         "${serviceName}-delayprofiles" = delayProfiles.mkService cfg.config;
       };
-    })
-    (mkIf (config.nixflix.enable && cfg.enable && config.nixflix.vpn.enable && cfg.vpn.enable) {
+    }
+    # Kept: upstream's VPN confinement block (simplified guard since outer mkIf checks enable)
+    (mkIf (config.nixflix.vpn.enable && cfg.vpn.enable) {
       systemd.services.${serviceName}.vpnConfinement = {
         enable = true;
         vpnNamespace = "wg";
@@ -496,5 +494,5 @@ in
         }
       ];
     })
-  ];
+  ]);
 }

--- a/modules/arr-common/mkArrServiceModule.nix
+++ b/modules/arr-common/mkArrServiceModule.nix
@@ -240,30 +240,30 @@ in
       themeParkService = serviceBase;
     })
     {
-    assertions = [
-      {
-        assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
-        message = "Cannot enable VPN routing for ${capitalizedName} (`config.nixflix.${serviceName}.vpn.enable = true`) when VPN is not enabled. Please set `nixflix.vpn.enable` = true.";
-      }
-      {
-        assertion =
-          (cfg.vpn.enable && config.nixflix.torrentClients.qbittorrent.enable)
-          -> config.nixflix.torrentClients.qbittorrent.vpn.enable;
-        message = "${capitalizedName} is VPN-confined but qBittorrent is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.torrentClients.qbittorrent.vpn.enable = true` or disable VPN for ${capitalizedName}.";
-      }
-      {
-        assertion =
-          (cfg.vpn.enable && config.nixflix.usenetClients.sabnzbd.enable)
-          -> config.nixflix.usenetClients.sabnzbd.vpn.enable;
-        message = "${capitalizedName} is VPN-confined but SABnzbd is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.usenetClients.sabnzbd.vpn.enable = true` or disable VPN for ${capitalizedName}.";
-      }
-      {
-        assertion =
-          (usesMediaDirs && cfg.vpn.enable && config.nixflix.prowlarr.enable)
-          -> config.nixflix.prowlarr.vpn.enable;
-        message = "${capitalizedName} is VPN-confined but Prowlarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.prowlarr.vpn.enable = true` or disable VPN for ${capitalizedName}.";
-      }
-    ];
+      assertions = [
+        {
+          assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
+          message = "Cannot enable VPN routing for ${capitalizedName} (`config.nixflix.${serviceName}.vpn.enable = true`) when VPN is not enabled. Please set `nixflix.vpn.enable` = true.";
+        }
+        {
+          assertion =
+            (cfg.vpn.enable && config.nixflix.torrentClients.qbittorrent.enable)
+            -> config.nixflix.torrentClients.qbittorrent.vpn.enable;
+          message = "${capitalizedName} is VPN-confined but qBittorrent is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.torrentClients.qbittorrent.vpn.enable = true` or disable VPN for ${capitalizedName}.";
+        }
+        {
+          assertion =
+            (cfg.vpn.enable && config.nixflix.usenetClients.sabnzbd.enable)
+            -> config.nixflix.usenetClients.sabnzbd.vpn.enable;
+          message = "${capitalizedName} is VPN-confined but SABnzbd is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.usenetClients.sabnzbd.vpn.enable = true` or disable VPN for ${capitalizedName}.";
+        }
+        {
+          assertion =
+            (usesMediaDirs && cfg.vpn.enable && config.nixflix.prowlarr.enable)
+            -> config.nixflix.prowlarr.vpn.enable;
+          message = "${capitalizedName} is VPN-confined but Prowlarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.prowlarr.vpn.enable = true` or disable VPN for ${capitalizedName}.";
+        }
+      ];
 
       nixflix.${serviceName} = {
         settings = {
@@ -293,7 +293,6 @@ in
         };
       };
 
-      # Removed: nginx.virtualHosts and networking.hosts — mkVirtualHost handles these
       services.postgresql = mkIf config.nixflix.postgres.enable {
         ensureDatabases = [
           cfg.settings.postgres.mainDb
@@ -402,7 +401,6 @@ in
           description = capitalizedName;
           environment = mkServarrSettingsEnvVars (toUpper serviceBase) cfg.settings;
 
-          # Added: mullvad-config.service dependency from caddy branch
           after = [
             "network.target"
             "nixflix-setup-dirs.service"
@@ -411,8 +409,7 @@ in
           ++ (optional (
             cfg.config.apiKey != null && cfg.config.hostConfig.password != null
           ) "${serviceName}-env.service")
-          ++ (optional config.nixflix.postgres.enable "postgresql-ready.target")
-          ++ (optional config.nixflix.mullvad.enable "mullvad-config.service");
+          ++ (optional config.nixflix.postgres.enable "postgresql-ready.target");
           requires = [
             "nixflix-setup-dirs.service"
           ]
@@ -421,8 +418,7 @@ in
             cfg.config.apiKey != null && cfg.config.hostConfig.password != null
           ) "${serviceName}-env.service")
           ++ (optional config.nixflix.postgres.enable "postgresql-ready.target");
-          # Changed: from empty list to mullvad wants
-          wants = optional config.nixflix.mullvad.enable "mullvad-config.service";
+          wants = [ ];
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = {
@@ -435,18 +431,6 @@ in
           }
           // optionalAttrs (cfg.config.apiKey != null && cfg.config.hostConfig.password != null) {
             EnvironmentFile = "/run/${serviceName}/env";
-          }
-          # Added: mullvad VPN bypass from caddy branch — wraps ExecStart
-          # with mullvad-exclude when mullvad is enabled but this service opts out
-          // optionalAttrs (config.nixflix.mullvad.enable && !cfg.vpn.enable) {
-            ExecStart = mkForce (
-              pkgs.writeShellScript "${serviceName}-vpn-bypass" ''
-                exec /run/wrappers/bin/mullvad-exclude ${getExe cfg.package} \
-                  -nobrowser -data='${stateDir}'
-              ''
-            );
-            AmbientCapabilities = "CAP_SYS_ADMIN";
-            Delegate = mkForce true;
           };
         };
       }
@@ -480,7 +464,6 @@ in
         "${serviceName}-delayprofiles" = delayProfiles.mkService cfg.config;
       };
     }
-    # Kept: upstream's VPN confinement block (simplified guard since outer mkIf checks enable)
     (mkIf (config.nixflix.vpn.enable && cfg.vpn.enable) {
       systemd.services.${serviceName}.vpnConfinement = {
         enable = true;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -51,7 +51,7 @@ in
         example = true;
         description = ''
           Enables themeing via [theme.park](https://docs.theme-park.dev/).
-          Requires `nixflix.nginx.enable = true;` for all services except Jellyfin.
+          Requires a reverse proxy (`nixflix.nginx.enable` or `nixflix.caddy.enable`) for all services except Jellyfin.
         '';
       };
       name = mkOption {
@@ -63,6 +63,58 @@ in
           - [Official Themes](https://docs.theme-park.dev/theme-options/)
           - [Community Themes](https://docs.theme-park.dev/community-themes/)
         '';
+      };
+    };
+
+    reverseProxy = {
+      enable = mkOption {
+        type = types.bool;
+        internal = true;
+        readOnly = true;
+        default = cfg.nginx.enable || cfg.caddy.enable;
+        description = "Whether any reverse proxy is enabled (derived, not user-facing).";
+      };
+
+      domain = mkOption {
+        type = types.str;
+        internal = true;
+        readOnly = true;
+        default =
+          if cfg.nginx.enable then
+            cfg.nginx.domain
+          else if cfg.caddy.enable then
+            cfg.caddy.domain
+          else
+            "nixflix";
+        description = "The active reverse proxy domain (derived).";
+      };
+
+      addHostsEntries = mkOption {
+        type = types.bool;
+        internal = true;
+        readOnly = true;
+        default =
+          if cfg.nginx.enable then
+            cfg.nginx.addHostsEntries
+          else if cfg.caddy.enable then
+            cfg.caddy.addHostsEntries
+          else
+            false;
+        description = "Whether to add hosts entries (derived).";
+      };
+
+      forceSSL = mkOption {
+        type = types.bool;
+        internal = true;
+        readOnly = true;
+        default =
+          if cfg.nginx.enable then
+            cfg.nginx.forceSSL
+          else if cfg.caddy.enable then
+            cfg.caddy.tls.enable
+          else
+            false;
+        description = "Whether SSL is forced (derived).";
       };
     };
 
@@ -106,6 +158,53 @@ in
 
           You have to configure `security.acme.certs.$${nixflix.nginx.domain}` in order to use this.
         '';
+      };
+    };
+
+    caddy = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable Caddy reverse proxy for all services.";
+      };
+
+      domain = mkOption {
+        type = types.str;
+        default = "nixflix";
+        example = "internal";
+        description = "Base domain for subdomain-based reverse proxy routing. Each service is accessible at `<subdomain>.<domain>`.";
+      };
+
+      addHostsEntries = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to add `networking.hosts` entries mapping service subdomains to `127.0.0.1`.
+
+          Enable if you don't have a separate DNS setup.
+        '';
+      };
+
+      tls = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to enable TLS. Caddy handles ACME automatically when enabled with a public domain.
+          '';
+        };
+
+        acmeEmail = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Email for ACME certificate registration. Required when using a public ACME provider.";
+        };
+
+        internal = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Use Caddy's internal (self-signed) CA instead of a public ACME provider. Useful for local/internal domains.";
+        };
       };
     };
 
@@ -189,6 +288,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.nginx.enable && cfg.caddy.enable);
+        message = "nixflix.nginx.enable and nixflix.caddy.enable are mutually exclusive. Choose one reverse proxy.";
+      }
+    ];
+
     users.groups.media = {
       gid = globals.gids.media;
       members = cfg.mediaUsers;
@@ -239,6 +345,19 @@ in
           return 444;
         '';
       };
+    };
+
+    services.caddy = mkIf cfg.caddy.enable {
+      enable = true;
+      package = mkIf cfg.theme.enable (
+        pkgs.caddy.withPlugins {
+          plugins = [ "github.com/caddyserver/replace-response@v0.0.0-20250618171559-80962887e4c6" ];
+          hash = "sha256-Li9eQjPeyOytfPdJXgtM3fh7qK/4WtgjmaweltQAk14=";
+        }
+      );
+      globalConfig = ''
+        ${optionalString (cfg.caddy.tls.acmeEmail != null) "email ${cfg.caddy.tls.acmeEmail}"}
+      '';
     };
   };
 }

--- a/modules/jellyfin/default.nix
+++ b/modules/jellyfin/default.nix
@@ -8,8 +8,9 @@ with lib;
 let
   inherit (config) nixflix;
   inherit (config.nixflix) globals;
+  inherit (import ../../lib/mkVirtualHosts.nix { inherit lib config; }) mkVirtualHost;
   cfg = config.nixflix.jellyfin;
-  hostname = "${cfg.subdomain}.${nixflix.nginx.domain}";
+  hostname = "${cfg.subdomain}.${nixflix.reverseProxy.domain}";
 
   xml = import ./xml.nix { inherit lib; };
 
@@ -53,9 +54,17 @@ in
     ./usersConfigService.nix
   ];
 
-  config = mkMerge [
-    (mkIf (nixflix.enable && cfg.enable) {
-      warnings = pluginResolution.resolutionWarnings;
+  config = mkIf (nixflix.enable && cfg.enable) (mkMerge [
+    (mkVirtualHost {
+      inherit hostname;
+      inherit (cfg.reverseProxy) expose;
+      port = cfg.network.internalHttpPort;
+      disableBuffering = true;
+      websocketUpgrade = true;
+    })
+    {
+    # Added: upstream's plugin resolution warnings
+    warnings = pluginResolution.resolutionWarnings;
 
       nixflix.jellyfin = {
         libraries = mkMerge [
@@ -282,7 +291,18 @@ in
             ${pkgs.coreutils}/bin/install -m 640 /etc/jellyfin/network.xml.template '${cfg.configDir}/network.xml'
           '';
 
-          ExecStart = "${getExe cfg.package} --datadir '${cfg.dataDir}' --configdir '${cfg.configDir}' --cachedir '${cfg.cacheDir}' --logdir '${cfg.logDir}'";
+          # Changed: conditional mullvad-exclude bypass from caddy branch
+          ExecStart =
+            if (config.nixflix.mullvad.enable && !cfg.vpn.enable) then
+              pkgs.writeShellScript "jellyfin-vpn-bypass" ''
+                exec /run/wrappers/bin/mullvad-exclude ${getExe cfg.package} \
+                  --datadir '${cfg.dataDir}' \
+                  --configdir '${cfg.configDir}' \
+                  --cachedir '${cfg.cacheDir}' \
+                  --logdir '${cfg.logDir}'
+              ''
+            else
+              "${getExe cfg.package} --datadir '${cfg.dataDir}' --configdir '${cfg.configDir}' --cachedir '${cfg.cacheDir}' --logdir '${cfg.logDir}'";
 
           ExecStartPost = waitForApiScript;
 
@@ -332,6 +352,14 @@ in
           ];
           SystemCallErrorNumber = "EPERM";
         }
+        # Added: mullvad bypass serviceConfig overrides from caddy branch
+        // optionalAttrs (config.nixflix.mullvad.enable && !cfg.vpn.enable) {
+          AmbientCapabilities = "CAP_SYS_ADMIN";
+          Delegate = mkForce true;
+          SystemCallFilter = mkForce [ ];
+          NoNewPrivileges = mkForce false;
+          ProtectControlGroups = mkForce false;
+        }
         // optionalAttrs cfg.encoding.enableHardwareEncoding {
           SupplementaryGroups = [
             "video"
@@ -351,40 +379,10 @@ in
         ];
       };
 
-      networking.hosts = mkIf (nixflix.nginx.enable && nixflix.nginx.addHostsEntries) {
-        "127.0.0.1" = [ hostname ];
-      };
-
-      services.nginx.virtualHosts."${hostname}" = mkIf nixflix.nginx.enable {
-        inherit (config.nixflix.nginx) forceSSL;
-        useACMEHost = if config.nixflix.nginx.enableACME then config.nixflix.nginx.domain else null;
-
-        locations =
-          let
-            proxyHost = if cfg.vpn.enable then config.vpnNamespaces.wg.namespaceAddress else "127.0.0.1";
-          in
-          {
-            "/" = {
-              proxyPass = "http://${proxyHost}:${toString cfg.network.internalHttpPort}";
-              recommendedProxySettings = true;
-              extraConfig = ''
-                proxy_set_header X-Real-IP $remote_addr;
-
-                proxy_buffering off;
-              '';
-            };
-            "/socket" = {
-              proxyPass = "http://${proxyHost}:${toString cfg.network.internalHttpPort}";
-              proxyWebsockets = true;
-              recommendedProxySettings = true;
-              extraConfig = ''
-                proxy_set_header X-Real-IP $remote_addr;
-              '';
-            };
-          };
-      };
-    })
-    (mkIf (nixflix.enable && cfg.enable && config.nixflix.vpn.enable && cfg.vpn.enable) {
+      # Removed: networking.hosts and services.nginx.virtualHosts — mkVirtualHost handles these
+    }
+    # Kept: upstream's VPN confinement block
+    (mkIf (config.nixflix.vpn.enable && cfg.vpn.enable) {
       systemd.services.jellyfin.vpnConfinement = {
         enable = true;
         vpnNamespace = "wg";
@@ -397,5 +395,5 @@ in
         }
       ];
     })
-  ];
+  ]);
 }

--- a/modules/jellyfin/default.nix
+++ b/modules/jellyfin/default.nix
@@ -63,8 +63,7 @@ in
       websocketUpgrade = true;
     })
     {
-    # Added: upstream's plugin resolution warnings
-    warnings = pluginResolution.resolutionWarnings;
+      warnings = pluginResolution.resolutionWarnings;
 
       nixflix.jellyfin = {
         libraries = mkMerge [
@@ -291,18 +290,7 @@ in
             ${pkgs.coreutils}/bin/install -m 640 /etc/jellyfin/network.xml.template '${cfg.configDir}/network.xml'
           '';
 
-          # Changed: conditional mullvad-exclude bypass from caddy branch
-          ExecStart =
-            if (config.nixflix.mullvad.enable && !cfg.vpn.enable) then
-              pkgs.writeShellScript "jellyfin-vpn-bypass" ''
-                exec /run/wrappers/bin/mullvad-exclude ${getExe cfg.package} \
-                  --datadir '${cfg.dataDir}' \
-                  --configdir '${cfg.configDir}' \
-                  --cachedir '${cfg.cacheDir}' \
-                  --logdir '${cfg.logDir}'
-              ''
-            else
-              "${getExe cfg.package} --datadir '${cfg.dataDir}' --configdir '${cfg.configDir}' --cachedir '${cfg.cacheDir}' --logdir '${cfg.logDir}'";
+          ExecStart = "${getExe cfg.package} --datadir '${cfg.dataDir}' --configdir '${cfg.configDir}' --cachedir '${cfg.cacheDir}' --logdir '${cfg.logDir}'";
 
           ExecStartPost = waitForApiScript;
 
@@ -352,14 +340,6 @@ in
           ];
           SystemCallErrorNumber = "EPERM";
         }
-        # Added: mullvad bypass serviceConfig overrides from caddy branch
-        // optionalAttrs (config.nixflix.mullvad.enable && !cfg.vpn.enable) {
-          AmbientCapabilities = "CAP_SYS_ADMIN";
-          Delegate = mkForce true;
-          SystemCallFilter = mkForce [ ];
-          NoNewPrivileges = mkForce false;
-          ProtectControlGroups = mkForce false;
-        }
         // optionalAttrs cfg.encoding.enableHardwareEncoding {
           SupplementaryGroups = [
             "video"
@@ -379,9 +359,7 @@ in
         ];
       };
 
-      # Removed: networking.hosts and services.nginx.virtualHosts — mkVirtualHost handles these
     }
-    # Kept: upstream's VPN confinement block
     (mkIf (config.nixflix.vpn.enable && cfg.vpn.enable) {
       systemd.services.jellyfin.vpnConfinement = {
         enable = true;

--- a/modules/jellyfin/options/default.nix
+++ b/modules/jellyfin/options/default.nix
@@ -106,7 +106,15 @@ in
     subdomain = mkOption {
       type = types.str;
       default = "jellyfin";
-      description = "Subdomain prefix for nginx reverse proxy.";
+      description = "Subdomain prefix for reverse proxy.";
+    };
+
+    reverseProxy = {
+      expose = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to expose Jellyfin via the reverse proxy.";
+      };
     };
 
     vpn = {

--- a/modules/jellyfin/options/network.nix
+++ b/modules/jellyfin/options/network.nix
@@ -98,19 +98,19 @@ in
 
     knownProxies = mkOption {
       type = types.listOf types.str;
-      default = if config.nixflix.nginx.enable then [ "127.0.0.1" ] else [ ];
+      default = if config.nixflix.reverseProxy.enable then [ "127.0.0.1" ] else [ ];
       description = "List of IP addresses or hostnames of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of 'X-Forwarded-For' headers.";
     };
 
     localNetworkAddresses = mkOption {
       type = types.listOf types.str;
       default =
-        if (config.nixflix.nginx.enable && !config.nixflix.jellyfin.vpn.enable) then
+        if (config.nixflix.reverseProxy.enable && !config.nixflix.jellyfin.vpn.enable) then
           [ "127.0.0.1" ]
         else
           [ ];
       defaultText = literalExpression ''
-        if (config.nixflix.nginx.enable && !config.nixflix.jellyfin.vpn.enable)
+        if (config.nixflix.reverseProxy.enable && !config.nixflix.jellyfin.vpn.enable)
         then [ "127.0.0.1" ]
         else [ ]
       '';

--- a/modules/jellyfin/systemConfigService.nix
+++ b/modules/jellyfin/systemConfigService.nix
@@ -14,7 +14,10 @@ let
   authUtil = import ./authUtil.nix { inherit lib pkgs cfg; };
 
   systemConfig = util.recursiveTransform (
-    (removeAttrs cfg.system [ "removeOldPlugins" ])
+    (removeAttrs cfg.system [
+      "removeOldPlugins"
+      "cachePath"
+    ])
     // {
       pluginRepositories = lib.mapAttrsToList (
         name: repo:

--- a/modules/jellyfin/systemConfigService.nix
+++ b/modules/jellyfin/systemConfigService.nix
@@ -14,10 +14,7 @@ let
   authUtil = import ./authUtil.nix { inherit lib pkgs cfg; };
 
   systemConfig = util.recursiveTransform (
-    (removeAttrs cfg.system [
-      "removeOldPlugins"
-      "cachePath"
-    ])
+    (removeAttrs cfg.system [ "removeOldPlugins" ])
     // {
       pluginRepositories = lib.mapAttrsToList (
         name: repo:

--- a/modules/seerr/default.nix
+++ b/modules/seerr/default.nix
@@ -28,266 +28,244 @@ in
       inherit (cfg.reverseProxy) expose;
       inherit (cfg) port;
       themeParkService = "overseerr";
-      themeParkTag = "</head>";
     })
     {
-    assertions =
-      let
-        radarrDefaults = filter (r: r.isDefault) (attrValues cfg.radarr);
-        radarrDefaultCount = length radarrDefaults;
-        radarrDefault4k = filter (r: r.is4k) radarrDefaults;
-        radarrDefaultNon4k = filter (r: !r.is4k) radarrDefaults;
+      assertions =
+        let
+          radarrDefaults = filter (r: r.isDefault) (attrValues cfg.radarr);
+          radarrDefaultCount = length radarrDefaults;
+          radarrDefault4k = filter (r: r.is4k) radarrDefaults;
+          radarrDefaultNon4k = filter (r: !r.is4k) radarrDefaults;
 
-        sonarrDefaults = filter (s: s.isDefault) (attrValues cfg.sonarr);
-        sonarrDefaultCount = length sonarrDefaults;
-        sonarrDefault4k = filter (s: s.is4k) sonarrDefaults;
-        sonarrDefaultNon4k = filter (s: !s.is4k) sonarrDefaults;
-      in
-      [
-        {
-          assertion = cfg.jellyfin.adminUsername != null && cfg.jellyfin.adminPassword != null;
-          message = "Seerr requires Jellyfin admin credentials. Either enable `nixflix.jellyfin` with an admin user, or set `nixflix.seerr.jellyfin.adminUsername` and `nixflix.seerr.jellyfin.adminPassword`.";
-        }
-        {
-          assertion = radarrDefaultCount <= 2;
-          message = "Cannot have more than 2 default Radarr instances in seerr.radarr. Found ${toString radarrDefaultCount} instances with isDefault = true.";
-        }
-        {
-          assertion =
-            radarrDefaultCount != 2 || (length radarrDefault4k == 1 && length radarrDefaultNon4k == 1);
-          message = "When there are 2 default Radarr instances, one must be 4K (is4k = true) and one must be non-4K (is4k = false).";
-        }
-        {
-          assertion = sonarrDefaultCount <= 2;
-          message = "Cannot have more than 2 default Sonarr instances in seerr.sonarr. Found ${toString sonarrDefaultCount} instances with isDefault = true.";
-        }
-        {
-          assertion =
-            sonarrDefaultCount != 2 || (length sonarrDefault4k == 1 && length sonarrDefaultNon4k == 1);
-          message = "When there are 2 default Sonarr instances, one must be 4K (is4k = true) and one must be non-4K (is4k = false).";
-        }
-        # Kept: upstream's VPN cross-check assertions
-        {
-          assertion =
-            (cfg.vpn.enable && config.nixflix.jellyfin.enable) -> config.nixflix.jellyfin.vpn.enable;
-          message = "Seerr is VPN-confined but Jellyfin is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.jellyfin.vpn.enable = true` or disable VPN for Seerr.";
-        }
-        {
-          assertion = (cfg.vpn.enable && config.nixflix.radarr.enable) -> config.nixflix.radarr.vpn.enable;
-          message = "Seerr is VPN-confined but Radarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.radarr.vpn.enable = true` or disable VPN for Seerr.";
-        }
-        {
-          assertion = (cfg.vpn.enable && config.nixflix.sonarr.enable) -> config.nixflix.sonarr.vpn.enable;
-          message = "Seerr is VPN-confined but Sonarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.sonarr.vpn.enable = true` or disable VPN for Seerr.";
-        }
-        {
-          assertion =
-            (cfg.vpn.enable && config.nixflix.sonarr-anime.enable) -> config.nixflix.sonarr-anime.vpn.enable;
-          message = "Seerr is VPN-confined but Sonarr Anime is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.sonarr-anime.vpn.enable = true` or disable VPN for Seerr.";
-        }
-      ];
-
-    users = {
-      groups.${cfg.group} = {
-        gid = mkForce config.nixflix.globals.gids.seerr;
-      };
-
-      users.${cfg.user} = {
-        inherit (cfg) group;
-        home = cfg.dataDir;
-        isSystemUser = true;
-        uid = mkForce config.nixflix.globals.uids.seerr;
-      };
-    };
-
-    systemd.tmpfiles.settings."10-seerr" = {
-      "/run/seerr".d = {
-        mode = "0755";
-        inherit (cfg) user group;
-      };
-      ${cfg.dataDir}.d = {
-        mode = "0755";
-        inherit (cfg) user group;
-      };
-    };
-
-    services.postgresql = mkIf config.nixflix.postgres.enable {
-      ensureDatabases = [ cfg.user ];
-      ensureUsers = [
-        {
-          name = cfg.user;
-          ensureDBOwnership = true;
-        }
-      ];
-    };
-
-    systemd.services = {
-      seerr-env = mkIf (cfg.apiKey != null) {
-        description = "Setup Seerr environment file";
-        wantedBy = [ "seerr.service" ];
-        before = [ "seerr.service" ];
-
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-        };
-
-        script = ''
-          mkdir -p /run/seerr
-          echo "API_KEY=${secrets.toShellValue cfg.apiKey}" > /run/seerr/env
-          chown ${cfg.user}:${cfg.group} /run/seerr/env
-          chmod 0400 /run/seerr/env
-        '';
-      };
-
-      seerr-wait-for-db = mkIf config.nixflix.postgres.enable {
-        description = "Wait for Seerr PostgreSQL database to be ready";
-        after = [
-          "postgresql.service"
-          "postgresql-setup.service"
+          sonarrDefaults = filter (s: s.isDefault) (attrValues cfg.sonarr);
+          sonarrDefaultCount = length sonarrDefaults;
+          sonarrDefault4k = filter (s: s.is4k) sonarrDefaults;
+          sonarrDefaultNon4k = filter (s: !s.is4k) sonarrDefaults;
+        in
+        [
+          {
+            assertion = cfg.jellyfin.adminUsername != null && cfg.jellyfin.adminPassword != null;
+            message = "Seerr requires Jellyfin admin credentials. Either enable `nixflix.jellyfin` with an admin user, or set `nixflix.seerr.jellyfin.adminUsername` and `nixflix.seerr.jellyfin.adminPassword`.";
+          }
+          {
+            assertion = radarrDefaultCount <= 2;
+            message = "Cannot have more than 2 default Radarr instances in seerr.radarr. Found ${toString radarrDefaultCount} instances with isDefault = true.";
+          }
+          {
+            assertion =
+              radarrDefaultCount != 2 || (length radarrDefault4k == 1 && length radarrDefaultNon4k == 1);
+            message = "When there are 2 default Radarr instances, one must be 4K (is4k = true) and one must be non-4K (is4k = false).";
+          }
+          {
+            assertion = sonarrDefaultCount <= 2;
+            message = "Cannot have more than 2 default Sonarr instances in seerr.sonarr. Found ${toString sonarrDefaultCount} instances with isDefault = true.";
+          }
+          {
+            assertion =
+              sonarrDefaultCount != 2 || (length sonarrDefault4k == 1 && length sonarrDefaultNon4k == 1);
+            message = "When there are 2 default Sonarr instances, one must be 4K (is4k = true) and one must be non-4K (is4k = false).";
+          }
+          {
+            assertion =
+              (cfg.vpn.enable && config.nixflix.jellyfin.enable) -> config.nixflix.jellyfin.vpn.enable;
+            message = "Seerr is VPN-confined but Jellyfin is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.jellyfin.vpn.enable = true` or disable VPN for Seerr.";
+          }
+          {
+            assertion = (cfg.vpn.enable && config.nixflix.radarr.enable) -> config.nixflix.radarr.vpn.enable;
+            message = "Seerr is VPN-confined but Radarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.radarr.vpn.enable = true` or disable VPN for Seerr.";
+          }
+          {
+            assertion = (cfg.vpn.enable && config.nixflix.sonarr.enable) -> config.nixflix.sonarr.vpn.enable;
+            message = "Seerr is VPN-confined but Sonarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.sonarr.vpn.enable = true` or disable VPN for Seerr.";
+          }
+          {
+            assertion =
+              (cfg.vpn.enable && config.nixflix.sonarr-anime.enable) -> config.nixflix.sonarr-anime.vpn.enable;
+            message = "Seerr is VPN-confined but Sonarr Anime is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.sonarr-anime.vpn.enable = true` or disable VPN for Seerr.";
+          }
         ];
-        before = [ "postgresql-ready.target" ];
-        requiredBy = [ "postgresql-ready.target" ];
 
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          TimeoutStartSec = "5min";
-          User = cfg.user;
-          Group = cfg.group;
+      users = {
+        groups.${cfg.group} = {
+          gid = mkForce config.nixflix.globals.gids.seerr;
         };
 
-        script = ''
-          while true; do
-            if ${pkgs.postgresql}/bin/psql -h /run/postgresql -d ${cfg.user} -c "SELECT 1" > /dev/null 2>&1; then
-              echo "Seerr PostgreSQL database is ready"
-              exit 0
-            fi
-            echo "Waiting for PostgreSQL role seerr..."
-            sleep 1
-          done
-        '';
-      };
-
-      seerr = {
-        description = "Seerr media request manager";
-
-        # Merged: both upstream's jellyfin-plugins.service and caddy's mullvad/setup-wizard deps
-        after = [
-          "network-online.target"
-          "nixflix-setup-dirs.service"
-        ]
-        ++ optional (cfg.apiKey != null) "seerr-env.service"
-        ++ optional config.nixflix.mullvad.enable "mullvad-config.service"
-        ++ optional config.nixflix.jellyfin.enable "jellyfin-setup-wizard.service"
-        ++ optional config.nixflix.jellyfin.enable "jellyfin-plugins.service"
-        ++ optional config.nixflix.postgres.enable "postgresql-ready.target"
-        ++ optional config.nixflix.recyclarr.enable "recyclarr.service"
-        ++ optional (
-          config.nixflix.recyclarr.enable && config.nixflix.recyclarr.cleanupUnmanagedProfiles.enable
-        ) "recyclarr-cleanup-profiles.service";
-
-        wants = [
-          "network-online.target"
-        ]
-        ++ optional config.nixflix.mullvad.enable "mullvad-config.service"
-        ++ optional config.nixflix.recyclarr.enable "recyclarr.service";
-
-        requires = [
-          "nixflix-setup-dirs.service"
-        ]
-        ++ optional config.nixflix.jellyfin.enable "jellyfin-setup-wizard.service"
-        ++ optional config.nixflix.jellyfin.enable "jellyfin-plugins.service"
-        ++ optional (cfg.apiKey != null) "seerr-env.service"
-        ++ optional config.nixflix.postgres.enable "postgresql-ready.target"
-        ++ optional (
-          config.nixflix.recyclarr.enable && config.nixflix.recyclarr.cleanupUnmanagedProfiles.enable
-        ) "recyclarr-cleanup-profiles.service";
-
-        wantedBy = [ "multi-user.target" ];
-
-        environment = {
-          HOST = mkIf config.nixflix.reverseProxy.enable "127.0.0.1";
-          PORT = toString cfg.port;
-          CONFIG_DIRECTORY = cfg.dataDir;
-        }
-        // optionalAttrs config.nixflix.postgres.enable {
-          DB_TYPE = "postgres";
-          DB_SOCKET_PATH = "/run/postgresql";
-          DB_USER = cfg.user;
-          DB_NAME = cfg.user;
-          DB_LOG_QUERIES = "false";
-        };
-
-        serviceConfig = {
-          Type = "simple";
-          User = cfg.user;
-          Group = cfg.group;
-          WorkingDirectory = cfg.dataDir;
-          Restart = "on-failure";
-
-          # Added: conditional mullvad-exclude bypass from caddy branch
-          ExecStart =
-            if (config.nixflix.mullvad.enable && !cfg.vpn.enable) then
-              pkgs.writeShellScript "seerr-vpn-bypass" ''
-                exec /run/wrappers/bin/mullvad-exclude ${getExe cfg.package}
-              ''
-            else
-              "${getExe cfg.package}";
-
-          # Security hardening
-          NoNewPrivileges = true;
-          PrivateTmp = true;
-          PrivateDevices = true;
-          ProtectSystem = "strict";
-          ProtectHome = true;
-          ReadWritePaths = cfg.dataDir;
-          RestrictAddressFamilies = [
-            "AF_UNIX"
-            "AF_INET"
-            "AF_INET6"
-          ];
-          LockPersonality = true;
-          ProtectControlGroups = true;
-          ProtectKernelLogs = true;
-          ProtectKernelModules = true;
-          ProtectKernelTunables = true;
-          RestrictNamespaces = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          SystemCallArchitectures = "native";
-          SystemCallFilter = [
-            "~@clock"
-            "~@debug"
-            "~@module"
-            "~@mount"
-            "~@reboot"
-            "~@swap"
-            "~@privileged"
-            "~@resources"
-          ];
-        }
-        // optionalAttrs (cfg.apiKey != null) {
-          EnvironmentFile = "/run/seerr/env";
-        }
-        # Added: mullvad bypass serviceConfig overrides from caddy branch
-        // optionalAttrs (config.nixflix.mullvad.enable && !cfg.vpn.enable) {
-          AmbientCapabilities = "CAP_SYS_ADMIN";
-          Delegate = mkForce true;
-          SystemCallFilter = mkForce [ ];
-          NoNewPrivileges = mkForce false;
-          ProtectControlGroups = mkForce false;
+        users.${cfg.user} = {
+          inherit (cfg) group;
+          home = cfg.dataDir;
+          isSystemUser = true;
+          uid = mkForce config.nixflix.globals.uids.seerr;
         };
       };
-    };
 
-    networking.firewall = mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.port ];
-    };
+      systemd.tmpfiles.settings."10-seerr" = {
+        "/run/seerr".d = {
+          mode = "0755";
+          inherit (cfg) user group;
+        };
+        ${cfg.dataDir}.d = {
+          mode = "0755";
+          inherit (cfg) user group;
+        };
+      };
 
-    # Removed: networking.hosts and services.nginx.virtualHosts — mkVirtualHost handles these
+      services.postgresql = mkIf config.nixflix.postgres.enable {
+        ensureDatabases = [ cfg.user ];
+        ensureUsers = [
+          {
+            name = cfg.user;
+            ensureDBOwnership = true;
+          }
+        ];
+      };
+
+      systemd.services = {
+        seerr-env = mkIf (cfg.apiKey != null) {
+          description = "Setup Seerr environment file";
+          wantedBy = [ "seerr.service" ];
+          before = [ "seerr.service" ];
+
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+
+          script = ''
+            mkdir -p /run/seerr
+            echo "API_KEY=${secrets.toShellValue cfg.apiKey}" > /run/seerr/env
+            chown ${cfg.user}:${cfg.group} /run/seerr/env
+            chmod 0400 /run/seerr/env
+          '';
+        };
+
+        seerr-wait-for-db = mkIf config.nixflix.postgres.enable {
+          description = "Wait for Seerr PostgreSQL database to be ready";
+          after = [
+            "postgresql.service"
+            "postgresql-setup.service"
+          ];
+          before = [ "postgresql-ready.target" ];
+          requiredBy = [ "postgresql-ready.target" ];
+
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            TimeoutStartSec = "5min";
+            User = cfg.user;
+            Group = cfg.group;
+          };
+
+          script = ''
+            while true; do
+              if ${pkgs.postgresql}/bin/psql -h /run/postgresql -d ${cfg.user} -c "SELECT 1" > /dev/null 2>&1; then
+                echo "Seerr PostgreSQL database is ready"
+                exit 0
+              fi
+              echo "Waiting for PostgreSQL role seerr..."
+              sleep 1
+            done
+          '';
+        };
+
+        seerr = {
+          description = "Seerr media request manager";
+
+          after = [
+            "network-online.target"
+            "nixflix-setup-dirs.service"
+          ]
+          ++ optional (cfg.apiKey != null) "seerr-env.service"
+          ++ optional config.nixflix.jellyfin.enable "jellyfin-setup-wizard.service"
+          ++ optional config.nixflix.jellyfin.enable "jellyfin-plugins.service"
+          ++ optional config.nixflix.postgres.enable "postgresql-ready.target"
+          ++ optional config.nixflix.recyclarr.enable "recyclarr.service"
+          ++ optional (
+            config.nixflix.recyclarr.enable && config.nixflix.recyclarr.cleanupUnmanagedProfiles.enable
+          ) "recyclarr-cleanup-profiles.service";
+
+          wants = [
+            "network-online.target"
+          ]
+          ++ optional config.nixflix.recyclarr.enable "recyclarr.service";
+
+          requires = [
+            "nixflix-setup-dirs.service"
+          ]
+          ++ optional config.nixflix.jellyfin.enable "jellyfin-setup-wizard.service"
+          ++ optional config.nixflix.jellyfin.enable "jellyfin-plugins.service"
+          ++ optional (cfg.apiKey != null) "seerr-env.service"
+          ++ optional config.nixflix.postgres.enable "postgresql-ready.target"
+          ++ optional (
+            config.nixflix.recyclarr.enable && config.nixflix.recyclarr.cleanupUnmanagedProfiles.enable
+          ) "recyclarr-cleanup-profiles.service";
+
+          wantedBy = [ "multi-user.target" ];
+
+          environment = {
+            HOST = mkIf config.nixflix.reverseProxy.enable "127.0.0.1";
+            PORT = toString cfg.port;
+            CONFIG_DIRECTORY = cfg.dataDir;
+          }
+          // optionalAttrs config.nixflix.postgres.enable {
+            DB_TYPE = "postgres";
+            DB_SOCKET_PATH = "/run/postgresql";
+            DB_USER = cfg.user;
+            DB_NAME = cfg.user;
+            DB_LOG_QUERIES = "false";
+          };
+
+          serviceConfig = {
+            Type = "simple";
+            User = cfg.user;
+            Group = cfg.group;
+            WorkingDirectory = cfg.dataDir;
+            Restart = "on-failure";
+
+            ExecStart = "${getExe cfg.package}";
+
+            # Security hardening
+            NoNewPrivileges = true;
+            PrivateTmp = true;
+            PrivateDevices = true;
+            ProtectSystem = "strict";
+            ProtectHome = true;
+            ReadWritePaths = cfg.dataDir;
+            RestrictAddressFamilies = [
+              "AF_UNIX"
+              "AF_INET"
+              "AF_INET6"
+            ];
+            LockPersonality = true;
+            ProtectControlGroups = true;
+            ProtectKernelLogs = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            SystemCallArchitectures = "native";
+            SystemCallFilter = [
+              "~@clock"
+              "~@debug"
+              "~@module"
+              "~@mount"
+              "~@reboot"
+              "~@swap"
+              "~@privileged"
+              "~@resources"
+            ];
+          }
+          // optionalAttrs (cfg.apiKey != null) {
+            EnvironmentFile = "/run/seerr/env";
+          };
+        };
+      };
+
+      networking.firewall = mkIf cfg.openFirewall {
+        allowedTCPPorts = [ cfg.port ];
+      };
+
     }
-    # Kept: upstream's VPN confinement block
     (mkIf (config.nixflix.vpn.enable && cfg.vpn.enable) {
       systemd.services.seerr.vpnConfinement = {
         enable = true;

--- a/modules/seerr/default.nix
+++ b/modules/seerr/default.nix
@@ -7,8 +7,9 @@
 with lib;
 let
   secrets = import ../../lib/secrets { inherit lib; };
+  inherit (import ../../lib/mkVirtualHosts.nix { inherit lib config; }) mkVirtualHost;
   cfg = config.nixflix.seerr;
-  hostname = "${cfg.subdomain}.${config.nixflix.nginx.domain}";
+  hostname = "${cfg.subdomain}.${config.nixflix.reverseProxy.domain}";
 in
 {
   imports = [
@@ -21,275 +22,273 @@ in
     ./userSettingsService.nix
   ];
 
-  config = mkMerge [
-    (mkIf (config.nixflix.enable && cfg.enable) {
-      assertions =
-        let
-          radarrDefaults = filter (r: r.isDefault) (attrValues cfg.radarr);
-          radarrDefaultCount = length radarrDefaults;
-          radarrDefault4k = filter (r: r.is4k) radarrDefaults;
-          radarrDefaultNon4k = filter (r: !r.is4k) radarrDefaults;
-
-          sonarrDefaults = filter (s: s.isDefault) (attrValues cfg.sonarr);
-          sonarrDefaultCount = length sonarrDefaults;
-          sonarrDefault4k = filter (s: s.is4k) sonarrDefaults;
-          sonarrDefaultNon4k = filter (s: !s.is4k) sonarrDefaults;
-        in
-        [
-          {
-            assertion = cfg.jellyfin.adminUsername != null && cfg.jellyfin.adminPassword != null;
-            message = "Seerr requires Jellyfin admin credentials. Either enable `nixflix.jellyfin` with an admin user, or set `nixflix.seerr.jellyfin.adminUsername` and `nixflix.seerr.jellyfin.adminPassword`.";
-          }
-          {
-            assertion = radarrDefaultCount <= 2;
-            message = "Cannot have more than 2 default Radarr instances in seerr.radarr. Found ${toString radarrDefaultCount} instances with isDefault = true.";
-          }
-          {
-            assertion =
-              radarrDefaultCount != 2 || (length radarrDefault4k == 1 && length radarrDefaultNon4k == 1);
-            message = "When there are 2 default Radarr instances, one must be 4K (is4k = true) and one must be non-4K (is4k = false).";
-          }
-          {
-            assertion = sonarrDefaultCount <= 2;
-            message = "Cannot have more than 2 default Sonarr instances in seerr.sonarr. Found ${toString sonarrDefaultCount} instances with isDefault = true.";
-          }
-          {
-            assertion =
-              sonarrDefaultCount != 2 || (length sonarrDefault4k == 1 && length sonarrDefaultNon4k == 1);
-            message = "When there are 2 default Sonarr instances, one must be 4K (is4k = true) and one must be non-4K (is4k = false).";
-          }
-          {
-            assertion =
-              (cfg.vpn.enable && config.nixflix.jellyfin.enable) -> config.nixflix.jellyfin.vpn.enable;
-            message = "Seerr is VPN-confined but Jellyfin is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.jellyfin.vpn.enable = true` or disable VPN for Seerr.";
-          }
-          {
-            assertion = (cfg.vpn.enable && config.nixflix.radarr.enable) -> config.nixflix.radarr.vpn.enable;
-            message = "Seerr is VPN-confined but Radarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.radarr.vpn.enable = true` or disable VPN for Seerr.";
-          }
-          {
-            assertion = (cfg.vpn.enable && config.nixflix.sonarr.enable) -> config.nixflix.sonarr.vpn.enable;
-            message = "Seerr is VPN-confined but Sonarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.sonarr.vpn.enable = true` or disable VPN for Seerr.";
-          }
-          {
-            assertion =
-              (cfg.vpn.enable && config.nixflix.sonarr-anime.enable) -> config.nixflix.sonarr-anime.vpn.enable;
-            message = "Seerr is VPN-confined but Sonarr Anime is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.sonarr-anime.vpn.enable = true` or disable VPN for Seerr.";
-          }
-        ];
-
-      users = {
-        groups.${cfg.group} = {
-          gid = mkForce config.nixflix.globals.gids.seerr;
-        };
-
-        users.${cfg.user} = {
-          inherit (cfg) group;
-          home = cfg.dataDir;
-          isSystemUser = true;
-          uid = mkForce config.nixflix.globals.uids.seerr;
-        };
-      };
-
-      systemd.tmpfiles.settings."10-seerr" = {
-        "/run/seerr".d = {
-          mode = "0755";
-          inherit (cfg) user group;
-        };
-        ${cfg.dataDir}.d = {
-          mode = "0755";
-          inherit (cfg) user group;
-        };
-      };
-
-      services.postgresql = mkIf config.nixflix.postgres.enable {
-        ensureDatabases = [ cfg.user ];
-        ensureUsers = [
-          {
-            name = cfg.user;
-            ensureDBOwnership = true;
-          }
-        ];
-      };
-
-      systemd.services = {
-        seerr-env = mkIf (cfg.apiKey != null) {
-          description = "Setup Seerr environment file";
-          wantedBy = [ "seerr.service" ];
-          before = [ "seerr.service" ];
-
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-          };
-
-          script = ''
-            mkdir -p /run/seerr
-            echo "API_KEY=${secrets.toShellValue cfg.apiKey}" > /run/seerr/env
-            chown ${cfg.user}:${cfg.group} /run/seerr/env
-            chmod 0400 /run/seerr/env
-          '';
-        };
-
-        seerr-wait-for-db = mkIf config.nixflix.postgres.enable {
-          description = "Wait for Seerr PostgreSQL database to be ready";
-          after = [
-            "postgresql.service"
-            "postgresql-setup.service"
-          ];
-          before = [ "postgresql-ready.target" ];
-          requiredBy = [ "postgresql-ready.target" ];
-
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-            TimeoutStartSec = "5min";
-            User = cfg.user;
-            Group = cfg.group;
-          };
-
-          script = ''
-            while true; do
-              if ${pkgs.postgresql}/bin/psql -h /run/postgresql -d ${cfg.user} -c "SELECT 1" > /dev/null 2>&1; then
-                echo "Seerr PostgreSQL database is ready"
-                exit 0
-              fi
-              echo "Waiting for PostgreSQL role seerr..."
-              sleep 1
-            done
-          '';
-        };
-
-        seerr = {
-          description = "Seerr media request manager";
-
-          after = [
-            "network-online.target"
-            "nixflix-setup-dirs.service"
-          ]
-          ++ optional (cfg.apiKey != null) "seerr-env.service"
-          ++ optional config.nixflix.jellyfin.enable "jellyfin-plugins.service"
-          ++ optional config.nixflix.postgres.enable "postgresql-ready.target"
-          ++ optional config.nixflix.recyclarr.enable "recyclarr.service"
-          ++ optional (
-            config.nixflix.recyclarr.enable && config.nixflix.recyclarr.cleanupUnmanagedProfiles.enable
-          ) "recyclarr-cleanup-profiles.service";
-
-          wants = [
-            "network-online.target"
-          ]
-          ++ optional config.nixflix.recyclarr.enable "recyclarr.service";
-
-          requires = [
-            "nixflix-setup-dirs.service"
-          ]
-          ++ optional config.nixflix.jellyfin.enable "jellyfin-plugins.service"
-          ++ optional (cfg.apiKey != null) "seerr-env.service"
-          ++ optional config.nixflix.postgres.enable "postgresql-ready.target"
-          ++ optional (
-            config.nixflix.recyclarr.enable && config.nixflix.recyclarr.cleanupUnmanagedProfiles.enable
-          ) "recyclarr-cleanup-profiles.service";
-
-          wantedBy = [ "multi-user.target" ];
-
-          environment = {
-            HOST = mkIf (config.nixflix.nginx.enable && !cfg.vpn.enable) "127.0.0.1";
-            PORT = toString cfg.port;
-            CONFIG_DIRECTORY = cfg.dataDir;
-          }
-          // optionalAttrs config.nixflix.postgres.enable {
-            DB_TYPE = "postgres";
-            DB_SOCKET_PATH = "/run/postgresql";
-            DB_USER = cfg.user;
-            DB_NAME = cfg.user;
-            DB_LOG_QUERIES = "false";
-          };
-
-          serviceConfig = {
-            Type = "simple";
-            User = cfg.user;
-            Group = cfg.group;
-            WorkingDirectory = cfg.dataDir;
-            Restart = "on-failure";
-
-            ExecStart = "${getExe cfg.package}";
-
-            # Security hardening
-            NoNewPrivileges = true;
-            PrivateTmp = true;
-            PrivateDevices = true;
-            ProtectSystem = "strict";
-            ProtectHome = true;
-            ReadWritePaths = cfg.dataDir;
-            RestrictAddressFamilies = [
-              "AF_UNIX"
-              "AF_INET"
-              "AF_INET6"
-            ];
-            LockPersonality = true;
-            ProtectControlGroups = true;
-            ProtectKernelLogs = true;
-            ProtectKernelModules = true;
-            ProtectKernelTunables = true;
-            RestrictNamespaces = true;
-            RestrictRealtime = true;
-            RestrictSUIDSGID = true;
-            SystemCallArchitectures = "native";
-            SystemCallFilter = [
-              "~@clock"
-              "~@debug"
-              "~@module"
-              "~@mount"
-              "~@reboot"
-              "~@swap"
-              "~@privileged"
-              "~@resources"
-            ];
-          }
-          // optionalAttrs (cfg.apiKey != null) {
-            EnvironmentFile = "/run/seerr/env";
-          };
-        };
-      };
-
-      networking.firewall = mkIf cfg.openFirewall {
-        allowedTCPPorts = [ cfg.port ];
-      };
-
-      networking.hosts = mkIf (config.nixflix.nginx.enable && config.nixflix.nginx.addHostsEntries) {
-        "127.0.0.1" = [ hostname ];
-      };
-
-      services.nginx.virtualHosts."${hostname}" =
-        let
-          themeParkUrl = "https://theme-park.dev/css/base/overseerr/${config.nixflix.theme.name}.css";
-          proxyHost = if cfg.vpn.enable then config.vpnNamespaces.wg.namespaceAddress else "127.0.0.1";
-        in
-        mkIf config.nixflix.nginx.enable {
-          inherit (config.nixflix.nginx) forceSSL;
-          useACMEHost = if config.nixflix.nginx.enableACME then config.nixflix.nginx.domain else null;
-
-          locations."/" = {
-            proxyPass = "http://${proxyHost}:${toString cfg.port}";
-            recommendedProxySettings = true;
-            extraConfig = ''
-              proxy_redirect off;
-
-              ${
-                if config.nixflix.theme.enable then
-                  ''
-                    proxy_set_header Accept-Encoding "";
-                    sub_filter '</head>' '<link rel="stylesheet" type="text/css" href="${themeParkUrl}"></head>';
-                    sub_filter_once on;
-                  ''
-                else
-                  ""
-              }
-            '';
-          };
-        };
+  config = mkIf (config.nixflix.enable && cfg.enable) (mkMerge [
+    (mkVirtualHost {
+      inherit hostname;
+      inherit (cfg.reverseProxy) expose;
+      inherit (cfg) port;
+      themeParkService = "overseerr";
+      themeParkTag = "</head>";
     })
-    (mkIf (config.nixflix.enable && cfg.enable && config.nixflix.vpn.enable && cfg.vpn.enable) {
+    {
+    assertions =
+      let
+        radarrDefaults = filter (r: r.isDefault) (attrValues cfg.radarr);
+        radarrDefaultCount = length radarrDefaults;
+        radarrDefault4k = filter (r: r.is4k) radarrDefaults;
+        radarrDefaultNon4k = filter (r: !r.is4k) radarrDefaults;
+
+        sonarrDefaults = filter (s: s.isDefault) (attrValues cfg.sonarr);
+        sonarrDefaultCount = length sonarrDefaults;
+        sonarrDefault4k = filter (s: s.is4k) sonarrDefaults;
+        sonarrDefaultNon4k = filter (s: !s.is4k) sonarrDefaults;
+      in
+      [
+        {
+          assertion = cfg.jellyfin.adminUsername != null && cfg.jellyfin.adminPassword != null;
+          message = "Seerr requires Jellyfin admin credentials. Either enable `nixflix.jellyfin` with an admin user, or set `nixflix.seerr.jellyfin.adminUsername` and `nixflix.seerr.jellyfin.adminPassword`.";
+        }
+        {
+          assertion = radarrDefaultCount <= 2;
+          message = "Cannot have more than 2 default Radarr instances in seerr.radarr. Found ${toString radarrDefaultCount} instances with isDefault = true.";
+        }
+        {
+          assertion =
+            radarrDefaultCount != 2 || (length radarrDefault4k == 1 && length radarrDefaultNon4k == 1);
+          message = "When there are 2 default Radarr instances, one must be 4K (is4k = true) and one must be non-4K (is4k = false).";
+        }
+        {
+          assertion = sonarrDefaultCount <= 2;
+          message = "Cannot have more than 2 default Sonarr instances in seerr.sonarr. Found ${toString sonarrDefaultCount} instances with isDefault = true.";
+        }
+        {
+          assertion =
+            sonarrDefaultCount != 2 || (length sonarrDefault4k == 1 && length sonarrDefaultNon4k == 1);
+          message = "When there are 2 default Sonarr instances, one must be 4K (is4k = true) and one must be non-4K (is4k = false).";
+        }
+        # Kept: upstream's VPN cross-check assertions
+        {
+          assertion =
+            (cfg.vpn.enable && config.nixflix.jellyfin.enable) -> config.nixflix.jellyfin.vpn.enable;
+          message = "Seerr is VPN-confined but Jellyfin is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.jellyfin.vpn.enable = true` or disable VPN for Seerr.";
+        }
+        {
+          assertion = (cfg.vpn.enable && config.nixflix.radarr.enable) -> config.nixflix.radarr.vpn.enable;
+          message = "Seerr is VPN-confined but Radarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.radarr.vpn.enable = true` or disable VPN for Seerr.";
+        }
+        {
+          assertion = (cfg.vpn.enable && config.nixflix.sonarr.enable) -> config.nixflix.sonarr.vpn.enable;
+          message = "Seerr is VPN-confined but Sonarr is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.sonarr.vpn.enable = true` or disable VPN for Seerr.";
+        }
+        {
+          assertion =
+            (cfg.vpn.enable && config.nixflix.sonarr-anime.enable) -> config.nixflix.sonarr-anime.vpn.enable;
+          message = "Seerr is VPN-confined but Sonarr Anime is not. Services inside the VPN namespace cannot reach services outside it. Set `nixflix.sonarr-anime.vpn.enable = true` or disable VPN for Seerr.";
+        }
+      ];
+
+    users = {
+      groups.${cfg.group} = {
+        gid = mkForce config.nixflix.globals.gids.seerr;
+      };
+
+      users.${cfg.user} = {
+        inherit (cfg) group;
+        home = cfg.dataDir;
+        isSystemUser = true;
+        uid = mkForce config.nixflix.globals.uids.seerr;
+      };
+    };
+
+    systemd.tmpfiles.settings."10-seerr" = {
+      "/run/seerr".d = {
+        mode = "0755";
+        inherit (cfg) user group;
+      };
+      ${cfg.dataDir}.d = {
+        mode = "0755";
+        inherit (cfg) user group;
+      };
+    };
+
+    services.postgresql = mkIf config.nixflix.postgres.enable {
+      ensureDatabases = [ cfg.user ];
+      ensureUsers = [
+        {
+          name = cfg.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    systemd.services = {
+      seerr-env = mkIf (cfg.apiKey != null) {
+        description = "Setup Seerr environment file";
+        wantedBy = [ "seerr.service" ];
+        before = [ "seerr.service" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+
+        script = ''
+          mkdir -p /run/seerr
+          echo "API_KEY=${secrets.toShellValue cfg.apiKey}" > /run/seerr/env
+          chown ${cfg.user}:${cfg.group} /run/seerr/env
+          chmod 0400 /run/seerr/env
+        '';
+      };
+
+      seerr-wait-for-db = mkIf config.nixflix.postgres.enable {
+        description = "Wait for Seerr PostgreSQL database to be ready";
+        after = [
+          "postgresql.service"
+          "postgresql-setup.service"
+        ];
+        before = [ "postgresql-ready.target" ];
+        requiredBy = [ "postgresql-ready.target" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          TimeoutStartSec = "5min";
+          User = cfg.user;
+          Group = cfg.group;
+        };
+
+        script = ''
+          while true; do
+            if ${pkgs.postgresql}/bin/psql -h /run/postgresql -d ${cfg.user} -c "SELECT 1" > /dev/null 2>&1; then
+              echo "Seerr PostgreSQL database is ready"
+              exit 0
+            fi
+            echo "Waiting for PostgreSQL role seerr..."
+            sleep 1
+          done
+        '';
+      };
+
+      seerr = {
+        description = "Seerr media request manager";
+
+        # Merged: both upstream's jellyfin-plugins.service and caddy's mullvad/setup-wizard deps
+        after = [
+          "network-online.target"
+          "nixflix-setup-dirs.service"
+        ]
+        ++ optional (cfg.apiKey != null) "seerr-env.service"
+        ++ optional config.nixflix.mullvad.enable "mullvad-config.service"
+        ++ optional config.nixflix.jellyfin.enable "jellyfin-setup-wizard.service"
+        ++ optional config.nixflix.jellyfin.enable "jellyfin-plugins.service"
+        ++ optional config.nixflix.postgres.enable "postgresql-ready.target"
+        ++ optional config.nixflix.recyclarr.enable "recyclarr.service"
+        ++ optional (
+          config.nixflix.recyclarr.enable && config.nixflix.recyclarr.cleanupUnmanagedProfiles.enable
+        ) "recyclarr-cleanup-profiles.service";
+
+        wants = [
+          "network-online.target"
+        ]
+        ++ optional config.nixflix.mullvad.enable "mullvad-config.service"
+        ++ optional config.nixflix.recyclarr.enable "recyclarr.service";
+
+        requires = [
+          "nixflix-setup-dirs.service"
+        ]
+        ++ optional config.nixflix.jellyfin.enable "jellyfin-setup-wizard.service"
+        ++ optional config.nixflix.jellyfin.enable "jellyfin-plugins.service"
+        ++ optional (cfg.apiKey != null) "seerr-env.service"
+        ++ optional config.nixflix.postgres.enable "postgresql-ready.target"
+        ++ optional (
+          config.nixflix.recyclarr.enable && config.nixflix.recyclarr.cleanupUnmanagedProfiles.enable
+        ) "recyclarr-cleanup-profiles.service";
+
+        wantedBy = [ "multi-user.target" ];
+
+        environment = {
+          HOST = mkIf config.nixflix.reverseProxy.enable "127.0.0.1";
+          PORT = toString cfg.port;
+          CONFIG_DIRECTORY = cfg.dataDir;
+        }
+        // optionalAttrs config.nixflix.postgres.enable {
+          DB_TYPE = "postgres";
+          DB_SOCKET_PATH = "/run/postgresql";
+          DB_USER = cfg.user;
+          DB_NAME = cfg.user;
+          DB_LOG_QUERIES = "false";
+        };
+
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          WorkingDirectory = cfg.dataDir;
+          Restart = "on-failure";
+
+          # Added: conditional mullvad-exclude bypass from caddy branch
+          ExecStart =
+            if (config.nixflix.mullvad.enable && !cfg.vpn.enable) then
+              pkgs.writeShellScript "seerr-vpn-bypass" ''
+                exec /run/wrappers/bin/mullvad-exclude ${getExe cfg.package}
+              ''
+            else
+              "${getExe cfg.package}";
+
+          # Security hardening
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          ReadWritePaths = cfg.dataDir;
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          LockPersonality = true;
+          ProtectControlGroups = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "~@clock"
+            "~@debug"
+            "~@module"
+            "~@mount"
+            "~@reboot"
+            "~@swap"
+            "~@privileged"
+            "~@resources"
+          ];
+        }
+        // optionalAttrs (cfg.apiKey != null) {
+          EnvironmentFile = "/run/seerr/env";
+        }
+        # Added: mullvad bypass serviceConfig overrides from caddy branch
+        // optionalAttrs (config.nixflix.mullvad.enable && !cfg.vpn.enable) {
+          AmbientCapabilities = "CAP_SYS_ADMIN";
+          Delegate = mkForce true;
+          SystemCallFilter = mkForce [ ];
+          NoNewPrivileges = mkForce false;
+          ProtectControlGroups = mkForce false;
+        };
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    # Removed: networking.hosts and services.nginx.virtualHosts — mkVirtualHost handles these
+    }
+    # Kept: upstream's VPN confinement block
+    (mkIf (config.nixflix.vpn.enable && cfg.vpn.enable) {
       systemd.services.seerr.vpnConfinement = {
         enable = true;
         vpnNamespace = "wg";
@@ -302,5 +301,5 @@ in
         }
       ];
     })
-  ];
+  ]);
 }

--- a/modules/seerr/options/default.nix
+++ b/modules/seerr/options/default.nix
@@ -75,7 +75,15 @@ in
     subdomain = mkOption {
       type = types.str;
       default = "seerr";
-      description = "Subdomain prefix for nginx reverse proxy.";
+      description = "Subdomain prefix for reverse proxy.";
+    };
+
+    reverseProxy = {
+      expose = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to expose Seerr via the reverse proxy.";
+      };
     };
 
     vpn = {

--- a/modules/seerr/options/jellyfin.nix
+++ b/modules/seerr/options/jellyfin.nix
@@ -78,13 +78,13 @@ in
       mkOption {
         type = types.str;
         default =
-          if config.nixflix.nginx.enable then
-            "${config.nixflix.seerr.externalUrlScheme}://${config.nixflix.jellyfin.subdomain}.${config.nixflix.nginx.domain}${jellyfinBaseUrl}"
+          if config.nixflix.reverseProxy.enable then
+            "${config.nixflix.seerr.externalUrlScheme}://${config.nixflix.jellyfin.subdomain}.${config.nixflix.reverseProxy.domain}${jellyfinBaseUrl}"
           else
             "";
         defaultText = literalExpression ''
-          if config.nixflix.nginx.enable != ""
-          then "$${config.nixflix.seerr.externalUrlScheme}://$${config.nixflix.jellyfin.subdomain}.$${config.nixflix.nginx.domain}"
+          if config.nixflix.reverseProxy.enable != ""
+          then "$${config.nixflix.seerr.externalUrlScheme}://$${config.nixflix.jellyfin.subdomain}.$${config.nixflix.reverseProxy.domain}"
           else "";
         '';
       };

--- a/modules/seerr/options/radarr.nix
+++ b/modules/seerr/options/radarr.nix
@@ -102,8 +102,8 @@ let
       activeDirectory = head (config.nixflix.radarr.mediaDirs or [ "/data/media/movies" ]);
       isDefault = true;
       externalUrl =
-        if config.nixflix.nginx.enable then
-          "${config.nixflix.seerr.externalUrlScheme}://${config.nixflix.radarr.subdomain}.${config.nixflix.nginx.domain}${config.nixflix.radarr.config.hostConfig.urlBase}"
+        if config.nixflix.reverseProxy.enable then
+          "${config.nixflix.seerr.externalUrlScheme}://${config.nixflix.radarr.subdomain}.${config.nixflix.reverseProxy.domain}${config.nixflix.radarr.config.hostConfig.urlBase}"
         else
           "";
     };

--- a/modules/seerr/options/sonarr.nix
+++ b/modules/seerr/options/sonarr.nix
@@ -135,8 +135,8 @@ let
         animeSeriesType = "standard";
         isDefault = true;
         externalUrl =
-          if config.nixflix.nginx.enable then
-            "${config.nixflix.seerr.externalUrlScheme}://${config.nixflix.sonarr.subdomain}.${config.nixflix.nginx.domain}${config.nixflix.sonarr.config.hostConfig.urlBase}"
+          if config.nixflix.reverseProxy.enable then
+            "${config.nixflix.seerr.externalUrlScheme}://${config.nixflix.sonarr.subdomain}.${config.nixflix.reverseProxy.domain}${config.nixflix.sonarr.config.hostConfig.urlBase}"
           else
             "";
       };
@@ -153,8 +153,8 @@ let
         animeSeriesType = "anime";
         isDefault = false;
         externalUrl =
-          if config.nixflix.nginx.enable then
-            "${config.nixflix.seerr.externalUrlScheme}://${config.nixflix.sonarr-anime.subdomain}.${config.nixflix.nginx.domain}${config.nixflix.sonarr-anime.config.hostConfig.urlBase}"
+          if config.nixflix.reverseProxy.enable then
+            "${config.nixflix.seerr.externalUrlScheme}://${config.nixflix.sonarr-anime.subdomain}.${config.nixflix.reverseProxy.domain}${config.nixflix.sonarr-anime.config.hostConfig.urlBase}"
           else
             "";
       };

--- a/modules/torrentClients/qbittorrent.nix
+++ b/modules/torrentClients/qbittorrent.nix
@@ -176,15 +176,13 @@ in
       ];
     })
     {
-    # Kept: upstream's VPN assertion
-    assertions = [
-      {
-        assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
-        message = "Cannot enable VPN routing for qBittorrent (nixflix.seerr.vpn.enable = true) when VPN is not enabled. Please set nixflix.vpn.enable = true.";
-      }
-    ];
+      assertions = [
+        {
+          assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
+          message = "Cannot enable VPN routing for qBittorrent (nixflix.torrentClients.qbittorrent.vpn.enable = true) when VPN is not enabled. Please set nixflix.vpn.enable = true.";
+        }
+      ];
 
-      # Merged: both caddy's "reverseProxy" and upstream's "vpn" in removeAttrs
       services.qbittorrent = builtins.removeAttrs cfg [
         "categories"
         "downloadsDir"
@@ -248,9 +246,7 @@ in
         );
       };
 
-    # Removed: networking.hosts and services.nginx.virtualHosts — mkVirtualHost handles these
     }
-    # Kept: upstream's VPN confinement block
     (mkIf (config.nixflix.vpn.enable && cfg.vpn.enable) {
       systemd.services.qbittorrent.vpnConfinement = {
         enable = true;

--- a/modules/torrentClients/qbittorrent.nix
+++ b/modules/torrentClients/qbittorrent.nix
@@ -7,10 +7,11 @@
 with lib;
 let
   secrets = import ../../lib/secrets { inherit lib; };
+  inherit (import ../../lib/mkVirtualHosts.nix { inherit lib config; }) mkVirtualHost;
   cfg = config.nixflix.torrentClients.qbittorrent;
   service = config.services.qbittorrent;
 
-  hostname = "${cfg.subdomain}.${config.nixflix.nginx.domain}";
+  hostname = "${cfg.subdomain}.${config.nixflix.reverseProxy.domain}";
   categoriesJson = builtins.toJSON (lib.mapAttrs (_name: path: { save_path = path; }) cfg.categories);
   categoriesFile = pkgs.writeText "categories.json" categoriesJson;
   configPath = "${service.profileDir}/qBittorrent/config";
@@ -116,7 +117,15 @@ in
         subdomain = mkOption {
           type = types.str;
           default = "qbittorrent";
-          description = "Subdomain prefix for nginx reverse proxy.";
+          description = "Subdomain prefix for reverse proxy.";
+        };
+
+        reverseProxy = {
+          expose = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Whether to expose qBittorrent via the reverse proxy.";
+          };
         };
 
         serverConfig = {
@@ -154,19 +163,33 @@ in
     default = { };
   };
 
-  config = mkMerge [
-    (mkIf (config.nixflix.enable && cfg != null && cfg.enable) {
-      assertions = [
-        {
-          assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
-          message = "Cannot enable VPN routing for qBittorrent (nixflix.seerr.vpn.enable = true) when VPN is not enabled. Please set nixflix.vpn.enable = true.";
-        }
+  config = mkIf (config.nixflix.enable && cfg != null && cfg.enable) (mkMerge [
+    (mkVirtualHost {
+      inherit hostname;
+      inherit (cfg.reverseProxy) expose;
+      port = service.webuiPort;
+      themeParkService = "qbittorrent";
+      stripHeaders = [
+        "x-webkit-csp"
+        "content-security-policy"
+        "X-Frame-Options"
       ];
+    })
+    {
+    # Kept: upstream's VPN assertion
+    assertions = [
+      {
+        assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
+        message = "Cannot enable VPN routing for qBittorrent (nixflix.seerr.vpn.enable = true) when VPN is not enabled. Please set nixflix.vpn.enable = true.";
+      }
+    ];
 
+      # Merged: both caddy's "reverseProxy" and upstream's "vpn" in removeAttrs
       services.qbittorrent = builtins.removeAttrs cfg [
         "categories"
         "downloadsDir"
         "password"
+        "reverseProxy"
         "subdomain"
         "vpn"
       ];
@@ -225,40 +248,10 @@ in
         );
       };
 
-      networking.hosts = mkIf (config.nixflix.nginx.enable && config.nixflix.nginx.addHostsEntries) {
-        "127.0.0.1" = [ hostname ];
-      };
-
-      services.nginx.virtualHosts."${hostname}" = mkIf config.nixflix.nginx.enable {
-        inherit (config.nixflix.nginx) forceSSL;
-        useACMEHost = if config.nixflix.nginx.enableACME then config.nixflix.nginx.domain else null;
-
-        locations."/" = {
-          proxyPass = "http://${cfg.serverConfig.Preferences.WebUI.Address}:${toString service.webuiPort}";
-          recommendedProxySettings = true;
-          extraConfig = ''
-            proxy_http_version 1.1;
-
-            ${
-              if config.nixflix.theme.enable then
-                ''
-                  proxy_set_header Accept-Encoding "";
-                  proxy_hide_header "x-webkit-csp";
-                  proxy_hide_header "content-security-policy";
-                  proxy_hide_header "X-Frame-Options";
-
-                  sub_filter '</body>' '<link rel="stylesheet" type="text/css" href="https://theme-park.dev/css/base/qbittorrent/${config.nixflix.theme.name}.css"></body>';
-                  sub_filter_once on;
-                ''
-              else
-                ""
-            }
-          '';
-        };
-      };
-
-    })
-    (mkIf (config.nixflix.enable && cfg.enable && config.nixflix.vpn.enable && cfg.vpn.enable) {
+    # Removed: networking.hosts and services.nginx.virtualHosts — mkVirtualHost handles these
+    }
+    # Kept: upstream's VPN confinement block
+    (mkIf (config.nixflix.vpn.enable && cfg.vpn.enable) {
       systemd.services.qbittorrent.vpnConfinement = {
         enable = true;
         vpnNamespace = "wg";
@@ -271,5 +264,5 @@ in
         }
       ];
     })
-  ];
+  ]);
 }

--- a/modules/usenetClients/sabnzbd/default.nix
+++ b/modules/usenetClients/sabnzbd/default.nix
@@ -6,8 +6,9 @@
 }:
 with lib;
 let
+  inherit (import ../../../lib/mkVirtualHosts.nix { inherit lib config; }) mkVirtualHost;
   cfg = config.nixflix.usenetClients.sabnzbd;
-  hostname = "${cfg.subdomain}.${config.nixflix.nginx.domain}";
+  hostname = "${cfg.subdomain}.${config.nixflix.reverseProxy.domain}";
 
   settingsType = import ./settingsType.nix { inherit lib config; };
   iniGenerator = import ./iniGenerator.nix { inherit lib; };
@@ -60,7 +61,15 @@ in
     subdomain = mkOption {
       type = types.str;
       default = "sabnzbd";
-      description = "Subdomain prefix for nginx reverse proxy.";
+      description = "Subdomain prefix for reverse proxy.";
+    };
+
+    reverseProxy = {
+      expose = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to expose SABnzbd via the reverse proxy.";
+      };
     };
 
     settings = mkOption {
@@ -77,6 +86,7 @@ in
       internal = true;
     };
 
+    # Kept: upstream's VPN option
     vpn = {
       enable = mkOption {
         type = types.bool;
@@ -92,155 +102,135 @@ in
     };
   };
 
-  config = mkMerge [
-    (mkIf (config.nixflix.enable && cfg.enable) {
-      assertions = [
-        {
-          assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
-          message = "Cannot enable VPN routing for SABnzbd (nixflix.seerr.vpn.enable = true) when VPN is not enabled. Please set nixflix.vpn.enable = true.";
-        }
-        {
-          assertion = cfg.settings.misc ? api_key && cfg.settings.misc.api_key ? _secret;
-          message = "nixflix.usenetClients.sabnzbd.settings.misc.api_key must be set with { _secret = /path; } for *arr integration";
-        }
-        {
-          assertion =
-            cfg.settings.misc ? url_base && builtins.match "^$|/.*[^/]$" cfg.settings.misc.url_base != null;
-          message = "nixflix.usenetClients.sabnzbd.settings.misc.url_base must either be an empty string or a string with a leading slash and no trailing slash, e.g. `/sabnzbd`";
-        }
-      ];
-
-      nixflix.usenetClients.sabnzbd.apiKeyPath = cfg.settings.misc.api_key._secret;
-
-      users.users.${cfg.user} = {
-        inherit (cfg) group;
-        uid = mkForce config.nixflix.globals.uids.sabnzbd;
-        home = stateDir;
-        isSystemUser = true;
-      };
-
-      users.groups.${cfg.group} = { };
-      systemd.tmpfiles.settings."10-sabnzbd" =
-        let
-          mkDir = dir: {
-            "${dir}".d = {
-              inherit (cfg) user group;
-              mode = "0775";
-            };
-          };
-        in
-        {
-          "${stateDir}".d = {
-            inherit (cfg) user group;
-            mode = "0755";
-          };
-        }
-        // lib.mergeAttrsList (
-          map mkDir [
-            cfg.downloadsDir
-            cfg.settings.misc.download_dir
-            cfg.settings.misc.complete_dir
-            cfg.settings.misc.dirscan_dir
-            cfg.settings.misc.nzb_backup_dir
-            cfg.settings.misc.admin_dir
-            cfg.settings.misc.log_dir
-          ]
-        );
-
-      environment.etc."sabnzbd/sabnzbd.ini.template".text = templateIni;
-
-      systemd.services.sabnzbd = {
-        description = "SABnzbd Usenet Downloader";
-        after = [
-          "network-online.target"
-          "nixflix-setup-dirs.service"
-        ];
-        requires = [ "nixflix-setup-dirs.service" ];
-        wants = [ "network-online.target" ];
-        wantedBy = [ "multi-user.target" ];
-        restartTriggers = [ config.environment.etc."sabnzbd/sabnzbd.ini.template".text ];
-
-        serviceConfig = {
-          Type = "simple";
-          User = cfg.user;
-          Group = cfg.group;
-
-          # Run with root privileges ('+' prefix) to read secrets owned by root
-          ExecStartPre =
-            "+"
-            + pkgs.writeShellScript "sabnzbd-prestart" ''
-              set -euo pipefail
-
-              echo "Merging secrets into SABnzbd configuration..."
-              ${pkgs.python3}/bin/python3 ${../../../lib/secrets/mergeSecrets.py} \
-                /etc/sabnzbd/sabnzbd.ini.template \
-                ${configFile}
-
-              ${pkgs.coreutils}/bin/chown ${cfg.user}:${cfg.group} ${configFile}
-              ${pkgs.coreutils}/bin/chmod 600 ${configFile}
-
-              echo "Configuration ready"
-            '';
-
-          ExecStart = "${getExe cfg.package} -f ${configFile} -s ${cfg.settings.misc.host}:${toString cfg.settings.misc.port} -b 0";
-
-          Restart = "on-failure";
-          RestartSec = "5s";
-
-          NoNewPrivileges = true;
-          PrivateTmp = true;
-          ProtectSystem = "strict";
-          ProtectHome = true;
-          ReadWritePaths = [
-            stateDir
-            cfg.downloadsDir
-            cfg.settings.misc.download_dir
-            cfg.settings.misc.complete_dir
-            cfg.settings.misc.dirscan_dir
-            cfg.settings.misc.nzb_backup_dir
-            cfg.settings.misc.admin_dir
-            cfg.settings.misc.log_dir
-          ];
-        };
-      };
-
-      networking.firewall = mkIf cfg.openFirewall {
-        allowedTCPPorts = [ cfg.settings.misc.port ];
-      };
-
-      networking.hosts = mkIf (config.nixflix.nginx.enable && config.nixflix.nginx.addHostsEntries) {
-        "127.0.0.1" = [ hostname ];
-      };
-
-      services.nginx.virtualHosts."${hostname}" = mkIf config.nixflix.nginx.enable {
-        inherit (config.nixflix.nginx) forceSSL;
-        useACMEHost = if config.nixflix.nginx.enableACME then config.nixflix.nginx.domain else null;
-
-        locations."/" = {
-          proxyPass = "http://${
-            if config.nixflix.vpn.enable then config.vpnNamespaces.wg.namespaceAddress else "127.0.0.1"
-          }:${toString cfg.settings.misc.port}";
-          recommendedProxySettings = true;
-          extraConfig = ''
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-
-            ${
-              if config.nixflix.theme.enable then
-                ''
-                  proxy_set_header Accept-Encoding "";
-                  sub_filter '</head>' '<link rel="stylesheet" type="text/css" href="https://theme-park.dev/css/base/sabnzbd/${config.nixflix.theme.name}.css"></head>';
-                  sub_filter_once on;
-                ''
-              else
-                ""
-            }
-          '';
-        };
-      };
-
+  config = mkIf (config.nixflix.enable && cfg.enable) (mkMerge [
+    (mkVirtualHost {
+      inherit hostname;
+      inherit (cfg.reverseProxy) expose;
+      inherit (cfg.settings.misc) port;
+      themeParkService = "sabnzbd";
+      themeParkTag = "</head>";
+      websocketUpgrade = true;
     })
-    (mkIf (config.nixflix.enable && cfg.enable && config.nixflix.vpn.enable && cfg.vpn.enable) {
+    {
+    assertions = [
+      # Kept: upstream's VPN assertion
+      {
+        assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
+        message = "Cannot enable VPN routing for SABnzbd (nixflix.usenetClients.sabnzbd.vpn.enable = true) when VPN is not enabled. Please set nixflix.vpn.enable = true.";
+      }
+      {
+        assertion = cfg.settings.misc ? api_key && cfg.settings.misc.api_key ? _secret;
+        message = "nixflix.usenetClients.sabnzbd.settings.misc.api_key must be set with { _secret = /path; } for *arr integration";
+      }
+      {
+        assertion =
+          cfg.settings.misc ? url_base && builtins.match "^$|/.*[^/]$" cfg.settings.misc.url_base != null;
+        message = "nixflix.usenetClients.sabnzbd.settings.misc.url_base must either be an empty string or a string with a leading slash and no trailing slash, e.g. `/sabnzbd`";
+      }
+    ];
+
+    nixflix.usenetClients.sabnzbd.apiKeyPath = cfg.settings.misc.api_key._secret;
+
+    users.users.${cfg.user} = {
+      inherit (cfg) group;
+      uid = mkForce config.nixflix.globals.uids.sabnzbd;
+      home = stateDir;
+      isSystemUser = true;
+    };
+
+    users.groups.${cfg.group} = { };
+    systemd.tmpfiles.settings."10-sabnzbd" =
+      let
+        mkDir = dir: {
+          "${dir}".d = {
+            inherit (cfg) user group;
+            mode = "0775";
+          };
+        };
+      in
+      {
+        "${stateDir}".d = {
+          inherit (cfg) user group;
+          mode = "0755";
+        };
+      }
+      // lib.mergeAttrsList (
+        map mkDir [
+          cfg.downloadsDir
+          cfg.settings.misc.download_dir
+          cfg.settings.misc.complete_dir
+          cfg.settings.misc.dirscan_dir
+          cfg.settings.misc.nzb_backup_dir
+          cfg.settings.misc.admin_dir
+          cfg.settings.misc.log_dir
+        ]
+      );
+
+    environment.etc."sabnzbd/sabnzbd.ini.template".text = templateIni;
+
+    systemd.services.sabnzbd = {
+      description = "SABnzbd Usenet Downloader";
+      after = [
+        "network-online.target"
+        "nixflix-setup-dirs.service"
+      ];
+      requires = [ "nixflix-setup-dirs.service" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ config.environment.etc."sabnzbd/sabnzbd.ini.template".text ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+
+        # Run with root privileges ('+' prefix) to read secrets owned by root
+        ExecStartPre =
+          "+"
+          + pkgs.writeShellScript "sabnzbd-prestart" ''
+            set -euo pipefail
+
+            echo "Merging secrets into SABnzbd configuration..."
+            ${pkgs.python3}/bin/python3 ${../../../lib/secrets/mergeSecrets.py} \
+              /etc/sabnzbd/sabnzbd.ini.template \
+              ${configFile}
+
+            ${pkgs.coreutils}/bin/chown ${cfg.user}:${cfg.group} ${configFile}
+            ${pkgs.coreutils}/bin/chmod 600 ${configFile}
+
+            echo "Configuration ready"
+          '';
+
+        ExecStart = "${getExe cfg.package} -f ${configFile} -s ${cfg.settings.misc.host}:${toString cfg.settings.misc.port} -b 0";
+
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [
+          stateDir
+          cfg.downloadsDir
+          cfg.settings.misc.download_dir
+          cfg.settings.misc.complete_dir
+          cfg.settings.misc.dirscan_dir
+          cfg.settings.misc.nzb_backup_dir
+          cfg.settings.misc.admin_dir
+          cfg.settings.misc.log_dir
+        ];
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.settings.misc.port ];
+    };
+
+    # Removed: networking.hosts and services.nginx.virtualHosts — mkVirtualHost handles these
+    }
+    # Kept: upstream's VPN confinement block
+    (mkIf (config.nixflix.vpn.enable && cfg.vpn.enable) {
       systemd.services.sabnzbd.vpnConfinement = {
         enable = true;
         vpnNamespace = "wg";
@@ -253,5 +243,5 @@ in
         }
       ];
     })
-  ];
+  ]);
 }

--- a/modules/usenetClients/sabnzbd/default.nix
+++ b/modules/usenetClients/sabnzbd/default.nix
@@ -86,7 +86,6 @@ in
       internal = true;
     };
 
-    # Kept: upstream's VPN option
     vpn = {
       enable = mkOption {
         type = types.bool;
@@ -108,128 +107,124 @@ in
       inherit (cfg.reverseProxy) expose;
       inherit (cfg.settings.misc) port;
       themeParkService = "sabnzbd";
-      themeParkTag = "</head>";
       websocketUpgrade = true;
     })
     {
-    assertions = [
-      # Kept: upstream's VPN assertion
-      {
-        assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
-        message = "Cannot enable VPN routing for SABnzbd (nixflix.usenetClients.sabnzbd.vpn.enable = true) when VPN is not enabled. Please set nixflix.vpn.enable = true.";
-      }
-      {
-        assertion = cfg.settings.misc ? api_key && cfg.settings.misc.api_key ? _secret;
-        message = "nixflix.usenetClients.sabnzbd.settings.misc.api_key must be set with { _secret = /path; } for *arr integration";
-      }
-      {
-        assertion =
-          cfg.settings.misc ? url_base && builtins.match "^$|/.*[^/]$" cfg.settings.misc.url_base != null;
-        message = "nixflix.usenetClients.sabnzbd.settings.misc.url_base must either be an empty string or a string with a leading slash and no trailing slash, e.g. `/sabnzbd`";
-      }
-    ];
-
-    nixflix.usenetClients.sabnzbd.apiKeyPath = cfg.settings.misc.api_key._secret;
-
-    users.users.${cfg.user} = {
-      inherit (cfg) group;
-      uid = mkForce config.nixflix.globals.uids.sabnzbd;
-      home = stateDir;
-      isSystemUser = true;
-    };
-
-    users.groups.${cfg.group} = { };
-    systemd.tmpfiles.settings."10-sabnzbd" =
-      let
-        mkDir = dir: {
-          "${dir}".d = {
-            inherit (cfg) user group;
-            mode = "0775";
-          };
-        };
-      in
-      {
-        "${stateDir}".d = {
-          inherit (cfg) user group;
-          mode = "0755";
-        };
-      }
-      // lib.mergeAttrsList (
-        map mkDir [
-          cfg.downloadsDir
-          cfg.settings.misc.download_dir
-          cfg.settings.misc.complete_dir
-          cfg.settings.misc.dirscan_dir
-          cfg.settings.misc.nzb_backup_dir
-          cfg.settings.misc.admin_dir
-          cfg.settings.misc.log_dir
-        ]
-      );
-
-    environment.etc."sabnzbd/sabnzbd.ini.template".text = templateIni;
-
-    systemd.services.sabnzbd = {
-      description = "SABnzbd Usenet Downloader";
-      after = [
-        "network-online.target"
-        "nixflix-setup-dirs.service"
+      assertions = [
+        {
+          assertion = cfg.vpn.enable -> config.nixflix.vpn.enable;
+          message = "Cannot enable VPN routing for SABnzbd (nixflix.usenetClients.sabnzbd.vpn.enable = true) when VPN is not enabled. Please set nixflix.vpn.enable = true.";
+        }
+        {
+          assertion = cfg.settings.misc ? api_key && cfg.settings.misc.api_key ? _secret;
+          message = "nixflix.usenetClients.sabnzbd.settings.misc.api_key must be set with { _secret = /path; } for *arr integration";
+        }
+        {
+          assertion =
+            cfg.settings.misc ? url_base && builtins.match "^$|/.*[^/]$" cfg.settings.misc.url_base != null;
+          message = "nixflix.usenetClients.sabnzbd.settings.misc.url_base must either be an empty string or a string with a leading slash and no trailing slash, e.g. `/sabnzbd`";
+        }
       ];
-      requires = [ "nixflix-setup-dirs.service" ];
-      wants = [ "network-online.target" ];
-      wantedBy = [ "multi-user.target" ];
-      restartTriggers = [ config.environment.etc."sabnzbd/sabnzbd.ini.template".text ];
 
-      serviceConfig = {
-        Type = "simple";
-        User = cfg.user;
-        Group = cfg.group;
+      nixflix.usenetClients.sabnzbd.apiKeyPath = cfg.settings.misc.api_key._secret;
 
-        # Run with root privileges ('+' prefix) to read secrets owned by root
-        ExecStartPre =
-          "+"
-          + pkgs.writeShellScript "sabnzbd-prestart" ''
-            set -euo pipefail
-
-            echo "Merging secrets into SABnzbd configuration..."
-            ${pkgs.python3}/bin/python3 ${../../../lib/secrets/mergeSecrets.py} \
-              /etc/sabnzbd/sabnzbd.ini.template \
-              ${configFile}
-
-            ${pkgs.coreutils}/bin/chown ${cfg.user}:${cfg.group} ${configFile}
-            ${pkgs.coreutils}/bin/chmod 600 ${configFile}
-
-            echo "Configuration ready"
-          '';
-
-        ExecStart = "${getExe cfg.package} -f ${configFile} -s ${cfg.settings.misc.host}:${toString cfg.settings.misc.port} -b 0";
-
-        Restart = "on-failure";
-        RestartSec = "5s";
-
-        NoNewPrivileges = true;
-        PrivateTmp = true;
-        ProtectSystem = "strict";
-        ProtectHome = true;
-        ReadWritePaths = [
-          stateDir
-          cfg.downloadsDir
-          cfg.settings.misc.download_dir
-          cfg.settings.misc.complete_dir
-          cfg.settings.misc.dirscan_dir
-          cfg.settings.misc.nzb_backup_dir
-          cfg.settings.misc.admin_dir
-          cfg.settings.misc.log_dir
-        ];
+      users.users.${cfg.user} = {
+        inherit (cfg) group;
+        uid = mkForce config.nixflix.globals.uids.sabnzbd;
+        home = stateDir;
+        isSystemUser = true;
       };
-    };
 
-    networking.firewall = mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.settings.misc.port ];
-    };
+      users.groups.${cfg.group} = { };
+      systemd.tmpfiles.settings."10-sabnzbd" =
+        let
+          mkDir = dir: {
+            "${dir}".d = {
+              inherit (cfg) user group;
+              mode = "0775";
+            };
+          };
+        in
+        {
+          "${stateDir}".d = {
+            inherit (cfg) user group;
+            mode = "0755";
+          };
+        }
+        // lib.mergeAttrsList (
+          map mkDir [
+            cfg.downloadsDir
+            cfg.settings.misc.download_dir
+            cfg.settings.misc.complete_dir
+            cfg.settings.misc.dirscan_dir
+            cfg.settings.misc.nzb_backup_dir
+            cfg.settings.misc.admin_dir
+            cfg.settings.misc.log_dir
+          ]
+        );
 
-    # Removed: networking.hosts and services.nginx.virtualHosts — mkVirtualHost handles these
+      environment.etc."sabnzbd/sabnzbd.ini.template".text = templateIni;
+
+      systemd.services.sabnzbd = {
+        description = "SABnzbd Usenet Downloader";
+        after = [
+          "network-online.target"
+          "nixflix-setup-dirs.service"
+        ];
+        requires = [ "nixflix-setup-dirs.service" ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+        restartTriggers = [ config.environment.etc."sabnzbd/sabnzbd.ini.template".text ];
+
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+
+          # Run with root privileges ('+' prefix) to read secrets owned by root
+          ExecStartPre =
+            "+"
+            + pkgs.writeShellScript "sabnzbd-prestart" ''
+              set -euo pipefail
+
+              echo "Merging secrets into SABnzbd configuration..."
+              ${pkgs.python3}/bin/python3 ${../../../lib/secrets/mergeSecrets.py} \
+                /etc/sabnzbd/sabnzbd.ini.template \
+                ${configFile}
+
+              ${pkgs.coreutils}/bin/chown ${cfg.user}:${cfg.group} ${configFile}
+              ${pkgs.coreutils}/bin/chmod 600 ${configFile}
+
+              echo "Configuration ready"
+            '';
+
+          ExecStart = "${getExe cfg.package} -f ${configFile} -s ${cfg.settings.misc.host}:${toString cfg.settings.misc.port} -b 0";
+
+          Restart = "on-failure";
+          RestartSec = "5s";
+
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          ReadWritePaths = [
+            stateDir
+            cfg.downloadsDir
+            cfg.settings.misc.download_dir
+            cfg.settings.misc.complete_dir
+            cfg.settings.misc.dirscan_dir
+            cfg.settings.misc.nzb_backup_dir
+            cfg.settings.misc.admin_dir
+            cfg.settings.misc.log_dir
+          ];
+        };
+      };
+
+      networking.firewall = mkIf cfg.openFirewall {
+        allowedTCPPorts = [ cfg.settings.misc.port ];
+      };
+
     }
-    # Kept: upstream's VPN confinement block
     (mkIf (config.nixflix.vpn.enable && cfg.vpn.enable) {
       systemd.services.sabnzbd.vpnConfinement = {
         enable = true;

--- a/modules/usenetClients/sabnzbd/settingsType.nix
+++ b/modules/usenetClients/sabnzbd/settingsType.nix
@@ -151,14 +151,14 @@ let
         default =
           if config.nixflix.vpn.enable && config.nixflix.usenetClients.sabnzbd.vpn.enable then
             config.vpnNamespaces.wg.namespaceAddress
-          else if config.nixflix.nginx.enable then
+          else if config.nixflix.reverseProxy.enable then
             "127.0.0.1"
           else
             "0.0.0.0";
         defaultText = lib.literalExpression ''
           if config.nixflix.vpn.enable && config.nixflix.usenetClients.sabnzbd.vpn.enable
           then config.vpnNamespaces.wg.namespaceAddress
-          else if config.nixflix.nginx.enable then "127.0.0.1"
+          else if config.nixflix.reverseProxy.enable then "127.0.0.1"
           else "0.0.0.0"
         '';
         example = "0.0.0.0";
@@ -168,11 +168,14 @@ let
       host_whitelist = mkOption {
         type = types.str;
         default =
-          if config.nixflix.nginx.enable then "${cfg.subdomain}.${config.nixflix.nginx.domain}" else "";
-        defaultText = lib.literalExpression ''if config.nixflix.nginx.enable then "''${cfg.subdomain}.''${config.nixflix.nginx.domain}" else ""'';
+          if config.nixflix.reverseProxy.enable then
+            "${cfg.subdomain}.${config.nixflix.reverseProxy.domain}"
+          else
+            "";
+        defaultText = lib.literalExpression ''if config.nixflix.reverseProxy.enable then "''${cfg.subdomain}.''${config.nixflix.reverseProxy.domain}" else ""'';
         description = ''
           Hostname verification whitelist. SABnzbd refuses connections from hostnames not in this list.
-          Automatically includes the service hostname when nginx is enabled.
+          Automatically includes the service hostname when a reverse proxy is enabled.
         '';
       };
 

--- a/tests/lib/mk-reverse-proxy-test.nix
+++ b/tests/lib/mk-reverse-proxy-test.nix
@@ -1,0 +1,239 @@
+# Shared integration test for reverse proxy backends (nginx/caddy).
+#
+# Takes a proxy config attrset and returns a NixOS VM test that verifies:
+# - All exposed services are accessible via their subdomain
+# - Services with `reverseProxy.expose = false` are NOT proxied
+# - Unexposed services are still reachable on localhost
+{
+  system ? builtins.currentSystem,
+  pkgs ? import <nixpkgs> { inherit system; },
+  nixosModules,
+  # e.g. { caddy = { enable = true; addHostsEntries = true; }; }
+  # or   { nginx = { enable = true; addHostsEntries = true; }; }
+  proxyConfig,
+  testName,
+}:
+let
+  pkgsUnfree = import pkgs.path {
+    inherit system;
+    config.allowUnfree = true;
+  };
+
+  proxyService =
+    if (proxyConfig ? caddy && proxyConfig.caddy.enable or false) then
+      "caddy"
+    else
+      "nginx";
+in
+pkgsUnfree.testers.runNixOSTest {
+  name = testName;
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ nixosModules ];
+
+      virtualisation = {
+        cores = 4;
+        memorySize = 4096;
+        diskSize = 3 * 1024;
+      };
+
+      nixflix = {
+        enable = true;
+
+        jellyfin = {
+          enable = true;
+          apiKey._secret = pkgs.writeText "jellyfin-apikey" "jellyfinApiKey1111111111111111111";
+          users = {
+            admin = {
+              password._secret = pkgs.writeText "kiri_password" "321password";
+              policy.isAdministrator = true;
+            };
+          };
+        };
+
+        seerr = {
+          enable = true;
+          apiKey._secret = pkgs.writeText "seerr-apikey" "seerr555555555555555555";
+        };
+
+        prowlarr = {
+          enable = true;
+          config = {
+            hostConfig = {
+              port = 9696;
+              username = "admin";
+              password._secret = pkgs.writeText "prowlarr-password" "testpass";
+            };
+            apiKey._secret = pkgs.writeText "prowlarr-apikey" "prowlarr11111111111111111111111111";
+          };
+        };
+
+        sonarr = {
+          enable = true;
+          user = "sonarr";
+          mediaDirs = [ "/media/tv" ];
+          config = {
+            hostConfig = {
+              port = 8989;
+              username = "admin";
+              password._secret = pkgs.writeText "sonarr-password" "testpass";
+            };
+            apiKey._secret = pkgs.writeText "sonarr-apikey" "sonarr222222222222222222222222222";
+          };
+        };
+
+        # Custom subdomain to test subdomain override
+        radarr = {
+          enable = true;
+          user = "radarr";
+          mediaDirs = [ "/media/movies" ];
+          subdomain = "movies";
+          config = {
+            hostConfig = {
+              port = 7878;
+              username = "admin";
+              password._secret = pkgs.writeText "radarr-password" "testpass";
+            };
+            apiKey._secret = pkgs.writeText "radarr-apikey" "radarr333333333333333333333333333";
+          };
+        };
+
+        # Lidarr has expose=false to test unexposed services
+        lidarr = {
+          enable = true;
+          user = "lidarr";
+          mediaDirs = [ "/media/music" ];
+          reverseProxy.expose = false;
+          config = {
+            hostConfig = {
+              port = 8686;
+              username = "admin";
+              password._secret = pkgs.writeText "lidarr-password" "testpass";
+            };
+            apiKey._secret = pkgs.writeText "lidarr-apikey" "lidarr444444444444444444444444444";
+          };
+        };
+
+        usenetClients.sabnzbd = {
+          enable = true;
+          downloadsDir = "/downloads/usenet";
+          settings = {
+            misc = {
+              api_key._secret = pkgs.writeText "sabnzbd-apikey" "sabnzbd555555555555555555555555555";
+              nzb_key._secret = pkgs.writeText "sabnzbd-nzbkey" "sabnzbd666666666666666666666666666";
+              port = 8080;
+              host = "127.0.0.1";
+            };
+          };
+        };
+      } // proxyConfig;
+    };
+
+  testScript = ''
+    start_all()
+
+    # Wait for reverse proxy
+    machine.wait_for_unit("${proxyService}.service", timeout=60)
+    machine.wait_for_open_port(80, timeout=60)
+
+    # Wait for all services
+    machine.wait_for_unit("sabnzbd.service", timeout=120)
+    machine.wait_for_unit("prowlarr.service", timeout=120)
+    machine.wait_for_unit("sonarr.service", timeout=120)
+    machine.wait_for_unit("radarr.service", timeout=120)
+    machine.wait_for_unit("lidarr.service", timeout=120)
+    machine.wait_for_open_port(8080, timeout=120)
+    machine.wait_for_open_port(9696, timeout=120)
+    machine.wait_for_open_port(8989, timeout=120)
+    machine.wait_for_open_port(7878, timeout=120)
+    machine.wait_for_open_port(8686, timeout=120)
+
+    # Wait for configuration services
+    machine.wait_for_unit("prowlarr-config.service", timeout=60)
+    machine.wait_for_unit("sonarr-config.service", timeout=60)
+    machine.wait_for_unit("radarr-config.service", timeout=60)
+    machine.wait_for_unit("lidarr-config.service", timeout=60)
+
+    # Wait for services to come back up after restart
+    machine.wait_for_unit("prowlarr.service", timeout=60)
+    machine.wait_for_unit("sonarr.service", timeout=60)
+    machine.wait_for_unit("radarr.service", timeout=60)
+    machine.wait_for_unit("lidarr.service", timeout=60)
+    machine.wait_for_unit("sabnzbd.service", timeout=60)
+    machine.wait_for_open_port(9696, timeout=60)
+    machine.wait_for_open_port(8989, timeout=60)
+    machine.wait_for_open_port(7878, timeout=60)
+    machine.wait_for_open_port(8686, timeout=60)
+    machine.wait_for_open_port(8080, timeout=60)
+
+    # Wait for Jellyfin
+    machine.wait_for_unit("jellyfin.service", timeout=180)
+    machine.wait_for_unit("jellyfin-api-key.service", timeout=180)
+    machine.wait_for_open_port(8096, timeout=180)
+
+    # Wait for seerr
+    machine.wait_for_unit("seerr.service", timeout=300)
+    machine.wait_for_open_port(5055, timeout=300)
+    machine.wait_for_unit("seerr-setup.service", timeout=300)
+
+    # --- Test exposed services are accessible via reverse proxy ---
+
+    print("Testing Prowlarr via reverse proxy...")
+    machine.succeed(
+        "curl -f http://prowlarr.nixflix/api/v1/system/status "
+        "-H 'X-Api-Key: prowlarr11111111111111111111111111'"
+    )
+
+    print("Testing Sonarr via reverse proxy...")
+    machine.succeed(
+        "curl -f http://sonarr.nixflix/api/v3/system/status "
+        "-H 'X-Api-Key: sonarr222222222222222222222222222'"
+    )
+
+    # Radarr uses a custom subdomain (subdomain = "movies")
+    print("Testing Radarr via custom subdomain (movies.nixflix)...")
+    machine.succeed(
+        "curl -f http://movies.nixflix/api/v3/system/status "
+        "-H 'X-Api-Key: radarr333333333333333333333333333'"
+    )
+
+    print("Testing Radarr is NOT accessible at default subdomain (radarr.nixflix)...")
+    machine.fail(
+        "curl -f http://radarr.nixflix/api/v3/system/status "
+        "-H 'X-Api-Key: radarr333333333333333333333333333'"
+    )
+
+    print("Testing SABnzbd via reverse proxy...")
+    machine.succeed(
+        "curl -f 'http://sabnzbd.nixflix/api?mode=version&apikey=sabnzbd555555555555555555555555555'"
+    )
+
+    print("Testing Jellyfin via reverse proxy...")
+    api_token = machine.succeed("cat /run/jellyfin/auth-token")
+    auth_header = f'"Authorization: {api_token}"'
+    base_url = 'http://jellyfin.nixflix'
+    machine.succeed(f'curl -f -H {auth_header} {base_url}/System/Info')
+
+    print("Testing Seerr via reverse proxy...")
+    machine.succeed('curl -f "http://seerr.nixflix/api/v1/status"')
+
+    # --- Test unexposed service (lidarr) is NOT accessible via reverse proxy ---
+
+    print("Testing Lidarr is NOT accessible via reverse proxy...")
+    machine.fail("curl -f http://lidarr.nixflix/api/v1/system/status "
+        "-H 'X-Api-Key: lidarr444444444444444444444444444'")
+
+    print("Testing Lidarr is still accessible on localhost...")
+    machine.succeed(
+        "curl -f http://127.0.0.1:8686/api/v1/system/status "
+        "-H 'X-Api-Key: lidarr444444444444444444444444444'"
+    )
+
+    # Verify no hosts entry was created for the unexposed service
+    machine.fail("grep -q 'lidarr.nixflix' /etc/hosts")
+
+    print("${testName} successful! Exposed services proxied, unexposed services correctly hidden.")
+  '';
+}

--- a/tests/lib/mk-reverse-proxy-test.nix
+++ b/tests/lib/mk-reverse-proxy-test.nix
@@ -132,9 +132,9 @@ pkgsUnfree.testers.runNixOSTest {
   testScript = ''
     start_all()
 
-    # Wait for reverse proxy
-    machine.wait_for_unit("${proxyService}.service", timeout=60)
-    machine.wait_for_open_port(80, timeout=60)
+    # Wait for reverse proxy (Caddy may need longer in resource-constrained CI)
+    machine.wait_for_unit("${proxyService}.service", timeout=120)
+    machine.wait_for_open_port(80, timeout=120)
 
     # Wait for all services
     machine.wait_for_unit("sabnzbd.service", timeout=120)

--- a/tests/lib/mk-reverse-proxy-test.nix
+++ b/tests/lib/mk-reverse-proxy-test.nix
@@ -20,10 +20,7 @@ let
   };
 
   proxyService =
-    if (proxyConfig ? caddy && proxyConfig.caddy.enable or false) then
-      "caddy"
-    else
-      "nginx";
+    if (proxyConfig ? caddy && proxyConfig.caddy.enable or false) then "caddy" else "nginx";
 in
 pkgsUnfree.testers.runNixOSTest {
   name = testName;
@@ -128,7 +125,8 @@ pkgsUnfree.testers.runNixOSTest {
             };
           };
         };
-      } // proxyConfig;
+      }
+      // proxyConfig;
     };
 
   testScript = ''

--- a/tests/vm-tests/caddy-integration.nix
+++ b/tests/vm-tests/caddy-integration.nix
@@ -5,9 +5,9 @@
 }:
 import ../lib/mk-reverse-proxy-test.nix {
   inherit system pkgs nixosModules;
-  testName = "nginx-integration-test";
+  testName = "caddy-integration-test";
   proxyConfig = {
-    nginx = {
+    caddy = {
       enable = true;
       addHostsEntries = true;
     };


### PR DESCRIPTION
## Summary

- Adds `nixflix.caddy.*` options as an alternative to `nixflix.nginx.*`, with mutual exclusivity assertion
- Introduces a thin `nixflix.reverseProxy.*` abstraction (read-only derived options) so service modules don't need to know which proxy backend is active
- Extracts `lib/mkVirtualHosts.nix` with a unified `mkVirtualHost` helper that returns a full NixOS config fragment (nginx vhost + caddy vhost + hosts entry) per service, eliminating duplicated proxy config across all modules
- Adds per-service `reverseProxy.expose` option (defaults to `true`) to control which services are proxied
- Refactors Jellyfin's nginx config to use the shared helper, using a single `/` location with websocket upgrade instead of separate `/` and `/socket` locations (manually tested, websocket upgrade confirmed working)
- Supports theme.park CSS injection via the `caddy-replace-response` plugin
- Deduplicates integration tests into a shared `tests/lib/mk-reverse-proxy-test.nix` helper, with coverage for exposed services, unexposed services (`reverseProxy.expose = false`), and custom subdomain overrides

## No breaking changes for existing nginx users

- All services default to `reverseProxy.expose = true`
- `subdomain` option stays at the same path (e.g. `nixflix.sonarr.subdomain`)
- Existing nginx configs continue to work without modification

## Note on `subdomain` placement

Ideally `subdomain` would live under `reverseProxy.subdomain` for consistency, but `mkRenamedOptionModule` doesn't work inside qbittorrent's freeform submodule, and I didn't want to introduce a breaking change without a clean deprecation path. What are your preferences around this?

## New options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `nixflix.caddy.enable` | bool | `false` | Enable Caddy as reverse proxy |
| `nixflix.caddy.domain` | str | `"nixflix"` | Domain for virtual hosts |
| `nixflix.caddy.addHostsEntries` | bool | `false` | Add `/etc/hosts` entries |
| `nixflix.caddy.tls.enable` | bool | `false` | Enable TLS |
| `nixflix.caddy.tls.acmeEmail` | str | | ACME email for cert provisioning |
| `nixflix.caddy.tls.internal` | bool | `false` | Use Caddy's internal CA |
| `nixflix.<service>.reverseProxy.expose` | bool | `true` | Per-service proxy toggle |

## Test plan

- [x] `caddy-integration` VM test passes (all services proxied via Caddy)
- [x] `nginx-integration` VM test passes (all services proxied via nginx)
- [x] Unexposed service test: not proxied but reachable on localhost, no hosts entry
- [x] Custom subdomain override test
- [x] Manual websocket test on real host (Jellyfin video playback through nginx)

## AI disclosure

This PR was AI-assisted (Claude Code). The approach was heavily iterated on and all generated code was reviewed and tested by me. I'll be responding to any feedback myself.

If AI-assisted contributions aren't welcome in this project, no worries at all. I'm happy to maintain this on my fork.