### PR TITLE
[BREAKING] Fix accidentally breaking existing postgres instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Breaking:** `nixflix.stateDir` default has been changed to `/var/lib` to match FHS convention
+
+  - You will need to move everything from `/data/.state` to `/var/lib`.
+  - `/data/.state/postgres` will need to be moved to `/var/lib/postgresql/<version>`.
+    - You can find `version` by running `sudo cat /data/.state/postgres/PG_VERSION`.
+
+- **Breaking:** unpin PostgreSQL version.
+
+  - If you're `stateVersion` is `25.11`, you will need to update your database version to 17 manually using `pg_upgrade` from `pkgs.postgresql_17`.
+
 - **Breaking:** `nixflix.mullvad.*` options have been replaced by
   `nixflix.vpn.*`. Update your configuration accordingly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,51 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Breaking:** unpin PostgreSQL version.
 
-  - If you're `stateVersion` is `25.11`, you will need to update your database version to 17 manually using `pg_upgrade` from `pkgs.postgresql_17`.
+  - If you're `stateVersion` is `25.11`, you will need to update your database version to 17 manually using `pg_upgrade` from `pkgs.postgresql_17`. You should probably stop the services that depend on PostgreSQL first. Perform the following steps:
+
+    1. ```bash
+       sudo -su postgres
+       ```
+    1. ```bash
+       cd /var/lib/postgresql/
+       ```
+    1. ```bash
+       old=16
+       new=17
+       ```
+    1. ```bash
+       pg_old=$(nix-build --no-out-link -E "with import <nixpkgs> {}; \
+               postgresql_${old:?}.withPackages (p: [ p.pgvector p.vectorchord ])")
+       pg_new=$(nix-build --no-out-link -E "with import <nixpkgs> {}; \
+               postgresql_${new:?}.withPackages (p: [ p.pgvector p.vectorchord ])")
+       ```
+    1. ```bash
+       # Init the new database
+       $pg_new/bin/initdb -D /var/lib/postgresql/$new || exit 1
+       ```
+    1. ```bash
+       # Check the upgrade
+       $pg_new/bin/pg_upgrade \
+         --socketdir=/var/run/postgresql \
+         --old-bindir=$pg_old/bin \
+         --new-bindir=$pg_new/bin \
+         --old-datadir=/var/lib/postgresql/${old:?} \
+         --new-datadir=/var/lib/postgresql/${new:?} \
+         --old-options "-c shared_preload_libraries='vchord.so'" \
+         --new-options "-c shared_preload_libraries='vchord.so'" \
+         --check # remove when ready to migrate
+       ```
+    1. ```bash
+       # Perform the upgrade
+       $pg_new/bin/pg_upgrade \
+         --socketdir=/var/run/postgresql \
+         --old-bindir=$pg_old/bin \
+         --new-bindir=$pg_new/bin \
+         --old-datadir=/var/lib/postgresql/${old:?} \
+         --new-datadir=/var/lib/postgresql/${new:?} \
+         --old-options "-c shared_preload_libraries='vchord.so'" \
+         --new-options "-c shared_preload_libraries='vchord.so'"
+       ```
 
 - **Breaking:** `nixflix.mullvad.*` options have been replaced by
   `nixflix.vpn.*`. Update your configuration accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - You will need to move everything from `/data/.state` to `/var/lib`.
   - `/data/.state/postgres` will need to be moved to `/var/lib/postgresql/<version>`.
     - You can find `version` by running `sudo cat /data/.state/postgres/PG_VERSION`.
+    - I also had to delete my `/var/lib/jellyfin` and `/var/lib/seerr` folders entirely after running the following (you may not have to, though):
+      ```sh
+      sudo systemctl stop jellyfin-api-key jellyfin-branding-config jellyfin-libraries jellyfin-plugins jellyfin-setup-wizard jellyfin-system-config jellyfin-users-config jellyfin seerr-jellyfin seerr-env seerr-setup seerr-user-settings seerr-wait-for-db seerr
+      ```
 
 - **Breaking:** unpin PostgreSQL version.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ title: Getting Started
   nixflix = {
     enable = true;
     mediaDir = "/data/media";
-    stateDir = "/data/.state/services";
+    stateDir = "/var/lib";
 
     sonarr = {
       enable = true;

--- a/modules/arr-common/mkArrServiceModule.nix
+++ b/modules/arr-common/mkArrServiceModule.nix
@@ -11,7 +11,6 @@ let
   inherit (import ../../lib/mkVirtualHosts.nix { inherit lib config; }) mkVirtualHost;
   inherit (config.nixflix) globals;
   cfg = config.nixflix.${serviceName};
-  stateDir = "${config.nixflix.stateDir}/${serviceName}";
 
   mkWaitForApiScript = import ./mkWaitForApiScript.nix { inherit lib pkgs; };
   hostConfig = import ./hostConfig.nix {
@@ -83,6 +82,13 @@ in
       type = types.str;
       default = serviceName;
       description = "Group under which the service runs";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "${config.nixflix.stateDir}/${serviceName}";
+      defaultText = literalExpression ''"''${config.nixflix.stateDir}/''${serviceName}"'';
+      description = "Directory containing Seerr data and configuration";
     };
 
     openFirewall = mkOption {
@@ -312,7 +318,7 @@ in
         };
         users.${cfg.user} = {
           inherit (cfg) group;
-          home = stateDir;
+          home = cfg.dataDir;
           isSystemUser = true;
         }
         // optionalAttrs (globals.uids ? ${cfg.user}) {
@@ -325,7 +331,7 @@ in
       };
 
       systemd.tmpfiles.settings."10-${serviceName}" = {
-        "${stateDir}".d = {
+        "${cfg.dataDir}".d = {
           inherit (cfg) user group;
           mode = "0755";
         };
@@ -426,7 +432,7 @@ in
             Type = "simple";
             User = cfg.user;
             Group = cfg.group;
-            ExecStart = "${getExe cfg.package} -nobrowser -data='${stateDir}'";
+            ExecStart = "${getExe cfg.package} -nobrowser -data='${cfg.dataDir}'";
             ExecStartPost = "+" + (mkWaitForApiScript serviceName cfg.config);
             Restart = "on-failure";
             UMask = "0002";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -265,7 +265,7 @@ in
 
     stateDir = mkOption {
       type = types.path;
-      default = "/data/.state";
+      default = "/var/lib";
       example = "/data/.state";
       description = ''
         The location of the state directory for the services.

--- a/modules/jellyfin/librariesService.nix
+++ b/modules/jellyfin/librariesService.nix
@@ -222,11 +222,13 @@ in
                     })
 
                     UPDATE_HTTP_CODE=$(echo "$UPDATE_RESPONSE" | tail -n1)
+                    UPDATE_BODY=$(echo "$UPDATE_RESPONSE" | sed '$d')
 
                     echo "Update library options response (HTTP $UPDATE_HTTP_CODE)"
 
                     if [ "$UPDATE_HTTP_CODE" -lt 200 ] || [ "$UPDATE_HTTP_CODE" -ge 300 ]; then
                       echo "Failed to update library options for ${libraryName} (HTTP $UPDATE_HTTP_CODE)" >&2
+                      echo "Response body: $UPDATE_BODY" >&2
                       exit 1
                     fi
 

--- a/modules/postgres.nix
+++ b/modules/postgres.nix
@@ -17,31 +17,12 @@ in
         Whether or not to enable postgresql for the entire stack.
       '';
     };
-
-    stateDir = mkOption {
-      type = types.path;
-      default =
-        if builtins.pathExists "/var/lib/postgresql/${config.services.postgresql.package.psqlSchema}" then
-          "/var/lib/postgresql/${config.services.postgresql.package.psqlSchema}"
-        else
-          "${config.nixflix.stateDir}/postgres";
-      defaultText = ''
-        if builtins.pathExists "/var/lib/postgresql/$${config.services.postgresql.package.psqlSchema}" then
-          "/var/lib/postgresql/$${config.services.postgresql.package.psqlSchema}"
-        else
-          "$${config.nixflix.stateDir}/postgres";
-      '';
-      example = "/var/lib/some/path";
-      description = ''
-        Path to store the PostgreSQL data.
-      '';
-    };
   };
 
   config = mkIf (config.nixflix.enable && cfg.enable) {
     services.postgresql = {
       enable = true;
-      dataDir = config.nixflix.postgres.stateDir;
+      dataDir = mkIf (config.nixflix.stateDir != "/var/lib") "${config.nixflix.stateDir}/postgres";
     };
 
     systemd.services.postgresql = {
@@ -50,10 +31,12 @@ in
     };
 
     systemd = {
-      tmpfiles.settings."10-postgresql".${config.nixflix.postgres.stateDir}.d = {
-        user = "postgres";
-        group = "postgres";
-        mode = "0700";
+      tmpfiles.settings."10-postgresql" = mkIf (config.nixflix.stateDir != "/var/lib") {
+        "${config.nixflix.stateDir}/postgres".d = {
+          user = "postgres";
+          group = "postgres";
+          mode = "0700";
+        };
       };
 
       targets.postgresql-ready = {

--- a/modules/postgres.nix
+++ b/modules/postgres.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 with lib;
@@ -16,29 +15,25 @@ in
       example = true;
       description = ''
         Whether or not to enable postgresql for the entire stack.
-
-        !!! warning
-
-            If you already have `services.postgresql.enable = true;`, then enabling this will break your current
-            configuration because `nixflix.postgresql.stateDir` changes the value of `services.postgresql.dataDir`.
-
-            Make sure to update `nixflix.postgresql.stateDir` accordingly.
       '';
     };
 
     stateDir = mkOption {
       type = types.path;
-      default = "${config.nixflix.stateDir}/postgres";
-      example = literalExpression ''"/var/lib/postgresql/$${config.services.postgresql.package.psqlSchema}"'';
+      default =
+        if builtins.pathExists "/var/lib/postgresql/${config.services.postgresql.package.psqlSchema}" then
+          "/var/lib/postgresql/${config.services.postgresql.package.psqlSchema}"
+        else
+          "${config.nixflix.stateDir}/postgres";
+      defaultText = ''
+        if builtins.pathExists "/var/lib/postgresql/$${config.services.postgresql.package.psqlSchema}" then
+          "/var/lib/postgresql/$${config.services.postgresql.package.psqlSchema}"
+        else
+          "$${config.nixflix.stateDir}/postgres";
+      '';
+      example = "/var/lib/some/path";
       description = ''
         Path to store the PostgreSQL data.
-
-        !!! warning
-
-            If you already have `services.postgresql.enable = true;`, then `nixflix.postgresql.enable = true;` will break your current
-            configuration because `nixflix.postgresql.stateDir` changes the value of `services.postgresql.dataDir`.
-
-            Make sure to update this option accordingly.
       '';
     };
   };
@@ -46,8 +41,7 @@ in
   config = mkIf (config.nixflix.enable && cfg.enable) {
     services.postgresql = {
       enable = true;
-      package = pkgs.postgresql_16;
-      dataDir = mkDefault config.nixflix.postgresql.stateDir;
+      dataDir = config.nixflix.postgres.stateDir;
     };
 
     systemd.services.postgresql = {
@@ -56,7 +50,7 @@ in
     };
 
     systemd = {
-      tmpfiles.settings."10-postgresql".${config.nixflix.postgresql.stateDir}.d = {
+      tmpfiles.settings."10-postgresql".${config.nixflix.postgres.stateDir}.d = {
         user = "postgres";
         group = "postgres";
         mode = "0700";

--- a/modules/postgres.nix
+++ b/modules/postgres.nix
@@ -7,7 +7,6 @@
 with lib;
 let
   cfg = config.nixflix.postgres;
-  stateDir = "${config.nixflix.stateDir}/postgres";
 in
 {
   options.nixflix.postgres = {
@@ -15,7 +14,32 @@ in
       type = types.bool;
       default = false;
       example = true;
-      description = "Whether or not to enable postgresql for the entire stack";
+      description = ''
+        Whether or not to enable postgresql for the entire stack.
+
+        !!! warning
+
+            If you already have `services.postgresql.enable = true;`, then enabling this will break your current
+            configuration because `nixflix.postgresql.stateDir` changes the value of `services.postgresql.dataDir`.
+
+            Make sure to update `nixflix.postgresql.stateDir` accordingly.
+      '';
+    };
+
+    stateDir = mkOption {
+      type = types.path;
+      default = "${config.nixflix.stateDir}/postgres";
+      example = literalExpression ''"/var/lib/postgresql/$${config.services.postgresql.package.psqlSchema}"'';
+      description = ''
+        Path to store the PostgreSQL data.
+
+        !!! warning
+
+            If you already have `services.postgresql.enable = true;`, then `nixflix.postgresql.enable = true;` will break your current
+            configuration because `nixflix.postgresql.stateDir` changes the value of `services.postgresql.dataDir`.
+
+            Make sure to update this option accordingly.
+      '';
     };
   };
 
@@ -23,7 +47,7 @@ in
     services.postgresql = {
       enable = true;
       package = pkgs.postgresql_16;
-      dataDir = stateDir;
+      dataDir = mkDefault config.nixflix.postgresql.stateDir;
     };
 
     systemd.services.postgresql = {
@@ -32,7 +56,7 @@ in
     };
 
     systemd = {
-      tmpfiles.settings."10-postgresql".${stateDir}.d = {
+      tmpfiles.settings."10-postgresql".${config.nixflix.postgresql.stateDir}.d = {
         user = "postgres";
         group = "postgres";
         mode = "0700";

--- a/tests/vm-tests/jellyfin-basic.nix
+++ b/tests/vm-tests/jellyfin-basic.nix
@@ -851,8 +851,8 @@ pkgs.testers.runNixOSTest {
             f"ComicVineApiKey should be 'comicvineapikey1111111111111111111', got {plugin_config.get('ComicVineApiKey')}"
 
         print("Verifying packaged plugin sync...")
-        machine.succeed("test -d '/data/.state/jellyfin/plugins/Bookshelf_13.0.0.0'")
-        machine.succeed("test -f '/data/.state/jellyfin/plugins/Bookshelf_13.0.0.0/Jellyfin.Plugin.Bookshelf.dll'")
+        machine.succeed("test -d '/var/lib/jellyfin/plugins/Bookshelf_13.0.0.0'")
+        machine.succeed("test -f '/var/lib/jellyfin/plugins/Bookshelf_13.0.0.0/Jellyfin.Plugin.Bookshelf.dll'")
 
         print("All plugin management assertions passed!")
   '';

--- a/tests/vm-tests/postgresql-integration.nix
+++ b/tests/vm-tests/postgresql-integration.nix
@@ -201,10 +201,10 @@ pkgs.testers.runNixOSTest {
     assert owner == "postgres", f"PostgreSQL directory owner incorrect: {owner}"
     assert group == "postgres", f"PostgreSQL directory group incorrect: {group}"
 
-    # Verify PostgreSQL is using version 16
+    # Verify PostgreSQL is using version 17
     print("Verifying PostgreSQL version...")
     version_output = machine.succeed("sudo -u postgres psql -t -c 'SHOW server_version;'")
-    assert "16." in version_output, f"PostgreSQL version incorrect: {version_output}"
+    assert "17." in version_output, f"PostgreSQL version incorrect: {version_output}"
 
     print("PostgreSQL integration test successful! All services running with PostgreSQL enabled.")
   '';


### PR DESCRIPTION
Resolves #173

I'm sorry about this one. It sucks. But I don't think there will be a breaking change near this bad in the future.

### Changed

- **Breaking:** `nixflix.stateDir` default has been changed to `/var/lib` to match FHS convention

  - You will need to move everything from `/data/.state` to `/var/lib`.
  - `/data/.state/postgres` will need to be moved to `/var/lib/postgresql/<version>`.
    - You can find `version` by running `sudo cat /data/.state/postgres/PG_VERSION`.
    - I also had to delete my `/var/lib/jellyfin` and `/var/lib/seerr` folders entirely after running the following (you may not have to, though):
      ```sh
      sudo systemctl stop jellyfin-api-key jellyfin-branding-config jellyfin-libraries jellyfin-plugins jellyfin-setup-wizard jellyfin-system-config jellyfin-users-config jellyfin seerr-jellyfin seerr-env seerr-setup seerr-user-settings seerr-wait-for-db seerr
      ```

- **Breaking:** unpin PostgreSQL version.
  - If you're `stateVersion` is `25.11`, you will need to update your database version to 17 manually using `pg_upgrade` from `pkgs.postgresql_17`. You should probably stop the services that depend on PostgreSQL first. Perform the following steps:

    1. ```bash
       sudo -su postgres
       ```
    1. ```bash
       cd /var/lib/postgresql/
       ```
    1. ```bash
       old=16
       new=17
       ```
    1. ```bash
       pg_old=$(nix-build --no-out-link -E "with import <nixpkgs> {}; \
               postgresql_${old:?}.withPackages (p: [ p.pgvector p.vectorchord ])")
       pg_new=$(nix-build --no-out-link -E "with import <nixpkgs> {}; \
               postgresql_${new:?}.withPackages (p: [ p.pgvector p.vectorchord ])")
       ```
    1. ```bash
       # Init the new database
       $pg_new/bin/initdb -D /var/lib/postgresql/$new || exit 1
       ```
    1. ```bash
       # Check the upgrade
       $pg_new/bin/pg_upgrade \
         --socketdir=/var/run/postgresql \
         --old-bindir=$pg_old/bin \
         --new-bindir=$pg_new/bin \
         --old-datadir=/var/lib/postgresql/${old:?} \
         --new-datadir=/var/lib/postgresql/${new:?} \
         --old-options "-c shared_preload_libraries='vchord.so'" \
         --new-options "-c shared_preload_libraries='vchord.so'" \
         --check # remove when ready to migrate
       ```
    1. ```bash
       # Perform the upgrade
       $pg_new/bin/pg_upgrade \
         --socketdir=/var/run/postgresql \
         --old-bindir=$pg_old/bin \
         --new-bindir=$pg_new/bin \
         --old-datadir=/var/lib/postgresql/${old:?} \
         --new-datadir=/var/lib/postgresql/${new:?} \
         --old-options "-c shared_preload_libraries='vchord.so'" \
         --new-options "-c shared_preload_libraries='vchord.so'"
       ```