### PR TITLE
Add default.nix for non-flake consumption

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,17 @@
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  vpn-confinement-src = fetchTarball {
+    url = "https://github.com/Maroka-chan/VPN-Confinement/archive/${lock.nodes.vpn-confinement.locked.rev}.tar.gz";
+    sha256 = lock.nodes.vpn-confinement.locked.narHash;
+  };
+  nixflixModule = {
+    imports = [
+      ./modules
+      "${vpn-confinement-src}/modules/vpn-netns.nix"
+    ];
+  };
+in
+{
+  nixosModules.default = nixflixModule;
+  nixosModules.nixflix = nixflixModule;
+}

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -8,12 +8,66 @@ This guide shows how to add Nixflix to your NixOS configuration using flakes.
 
 ## Prerequisites
 
-- NixOS with flakes enabled
+- NixOS
 - Git for version control
 - Basic familiarity with NixOS modules
 - Some form of secrets management, like [sops-nix](https://github.com/Mic92/sops-nix)
 
-## Enable Flakes
+From here, you have two ways of using Nixflix in your configuration, those being with and without Flakes.
+
+## Without Flakes
+
+The `default.nix` at the root of the repository exposes the NixOS module for non-flake users.
+
+### With `builtins.fetchTarball`
+
+```nix
+let
+  nixflix = import (builtins.fetchTarball "https://github.com/kiriwalawren/nixflix/archive/main.tar.gz") {};
+  # You can pin the module to a specific commit by replacing main with the commit's hash
+in {
+  imports = [ nixflix.nixosModules.default ];
+}
+```
+
+### With `pkgs.fetchFromGitHub`
+
+```nix
+{ pkgs, ... }:
+let
+  nixflix = import (pkgs.fetchFromGitHub {
+    owner = "kiriwalawren";
+    repo = "nixflix";
+    rev = "main"; # You can use the rev to pin the module to a specific commit using it's hash
+    sha256 = ""; # replace with the actual hash which will likely be returned after your rebuild errors out.
+  }) {};
+in {
+  imports = [ nixflix.nixosModules.default ];
+}
+```
+
+### With [npins](https://github.com/andir/npins)
+
+First, add nixflix to your pins:
+
+```bash
+npins add github kiriwalawren nixflix --branch main
+```
+
+Then import the module:
+
+```nix
+let
+  sources = import path/to/npins/folder;
+  nixflix = import sources.nixflix {};
+in {
+  imports = [ nixflix.nixosModules.default ];
+}
+```
+These aren't the only ways to add the Nixflix module to your configuration (you could use `builtins.fetchGit` for example) although they are the most common ones.
+
+## With Flakes
+### Enable Flakes
 
 If you haven't already enabled flakes, add this to your configuration:
 
@@ -23,7 +77,7 @@ If you haven't already enabled flakes, add this to your configuration:
 }
 ```
 
-## Adding Nixflix to Your Flake
+### Adding Nixflix to Your Flake
 
 Add Nixflix as an input to your `flake.nix`:
 


### PR DESCRIPTION
Add a `default.nix` file that exposes the Nixflix NixOS module, for consumption through `pkgs.fetchFromGithub`, `npins` and such. It currently uses the `flake.lock` to read VPN-Confinment's revision ; this way, the process of updating the dependencies of the project will stay the same.

Tested using `nix repl`: 
```
nix-repl> :l ./default.nix
Added 1 variables.

nix-repl> nixosModules
{
  default = { ... };
  nixflix = «repeated»;
}
```

Closes #182.