### PR TITLE
Expose lib.jellyfinPlugins and lib.buildJellyfinPlugin through default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,7 @@
-{pkgs ? import <nixpkgs> {}}: let
+{
+  pkgs ? import <nixpkgs> { },
+}:
+let
   lock = builtins.fromJSON (builtins.readFile ./flake.lock);
   vpn-confinement-src = fetchTarball {
     url = "https://github.com/Maroka-chan/VPN-Confinement/archive/${lock.nodes.vpn-confinement.locked.rev}.tar.gz";
@@ -10,9 +13,10 @@
       "${vpn-confinement-src}/modules/vpn-netns.nix"
     ];
   };
-in {
+in
+{
   nixosModules.default = nixflixModule;
   nixosModules.nixflix = nixflixModule;
-  lib.jellyfinPlugins = import ./lib/jellyfin-plugins.nix {inherit (pkgs) lib;};
-  lib.buildJellyfinPlugin = import ./lib/build-jellyfin-plugin.nix {inherit pkgs;};
+  lib.jellyfinPlugins = import ./lib/jellyfin-plugins.nix { inherit (pkgs) lib; };
+  lib.buildJellyfinPlugin = import ./lib/build-jellyfin-plugin.nix { inherit pkgs; };
 }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-let
+{pkgs ? import <nixpkgs> {}}: let
   lock = builtins.fromJSON (builtins.readFile ./flake.lock);
   vpn-confinement-src = fetchTarball {
     url = "https://github.com/Maroka-chan/VPN-Confinement/archive/${lock.nodes.vpn-confinement.locked.rev}.tar.gz";
@@ -10,8 +10,9 @@ let
       "${vpn-confinement-src}/modules/vpn-netns.nix"
     ];
   };
-in
-{
+in {
   nixosModules.default = nixflixModule;
   nixosModules.nixflix = nixflixModule;
+  lib.jellyfinPlugins = import ./lib/jellyfin-plugins.nix {inherit (pkgs) lib;};
+  lib.buildJellyfinPlugin = import ./lib/build-jellyfin-plugin.nix {inherit pkgs;};
 }

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -16,22 +16,18 @@ This guide shows how to add Nixflix to your NixOS configuration using flakes.
 From here, you have two ways of using Nixflix in your configuration, those being with and without Flakes.
 
 ## Without Flakes
-
 The `default.nix` at the root of the repository exposes the NixOS module for non-flake users.
-
 ### With `builtins.fetchTarball`
-
 ```nix
+{ pkgs, ... }:
 let
-  nixflix = import (builtins.fetchTarball "https://github.com/kiriwalawren/nixflix/archive/main.tar.gz");
+  nixflix = import (builtins.fetchTarball "https://github.com/kiriwalawren/nixflix/archive/main.tar.gz") { inherit pkgs; };
   # You can pin the module to a specific commit by replacing main with the commit's hash
 in {
   imports = [ nixflix.nixosModules.default ];
 }
 ```
-
 ### With `pkgs.fetchFromGitHub`
-
 ```nix
 { pkgs, ... }:
 let
@@ -40,32 +36,27 @@ let
     repo = "nixflix";
     rev = "main"; # You can use the rev to pin the module to a specific commit using its hash
     sha256 = ""; # replace with the actual hash which will likely be returned after your rebuild errors out.
-  });
+  }) { inherit pkgs; };
 in {
   imports = [ nixflix.nixosModules.default ];
 }
 ```
-
 ### With [npins](https://github.com/andir/npins)
-
 First, add nixflix to your pins:
-
 ```bash
 npins add github kiriwalawren nixflix --branch main
 ```
-
 Then import the module:
-
 ```nix
+{ pkgs, ... }:
 let
   sources = import path/to/npins/folder;
-  nixflix = import sources.nixflix;
+  nixflix = import sources.nixflix { inherit pkgs; };
 in {
   imports = [ nixflix.nixosModules.default ];
 }
 ```
 These aren't the only ways to add the Nixflix module to your configuration (you could use `builtins.fetchGit` for example) although they are the most common ones.
-
 ## With Flakes
 ### Enable Flakes
 


### PR DESCRIPTION
Hello again ! 

While configuring Nixflix, I wanted to use lib.jellyfinPlugins to configure the opensubtitles plugin. However, I noticed my default.nix didn't expose those at all ; this PR aims to fix this. I've also took the liberty to update the documentation since `default.nix` is now a function that takes nixpkgs as a parameter.

As always, I've tested the PR using `nix repl` and it seems to work ! 

```
nix-repl> :l ./default.nix             
Added 2 variables.

nix-repl> lib.jellyfinPlugins
{ fromRepo = «lambda fromRepo @ /home/agahnim/Repos/nixflix/lib/jellyfin-plugins.nix:3:5»; }

nix-repl> lib.buildJellyfinPlugin
«lambda buildJellyfinPlugin @ /home/agahnim/Repos/nixflix/default.nix:21:29»
```