### PR TITLE
fix dynamic vpn connection address of all services

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,9 @@
           docs-build = self.packages.${system}.docs;
         }
         // tests.vm-tests
-        // tests.unit-tests
+        // {
+          unit-tests = pkgs.linkFarmFromDrvs "unit-tests" (lib.attrValues tests.unit-tests);
+        }
       );
 
       devShells = perSystem (

--- a/modules/arr-common/hostConfigType.nix
+++ b/modules/arr-common/hostConfigType.nix
@@ -14,8 +14,10 @@ types.submodule {
       default =
         if config.nixflix.vpn.enable && serviceConfig.vpn.enable then
           config.vpnNamespaces.wg.namespaceAddress
+        else if config.nixflix.reverseProxy.enable then
+          "127.0.0.1"
         else
-          "127.0.0.1";
+          "0.0.0.0";
       description = "Address to bind to";
     };
 

--- a/modules/arr-common/mkArrServiceModule.nix
+++ b/modules/arr-common/mkArrServiceModule.nix
@@ -72,6 +72,17 @@ in
       };
     };
 
+    connectionAddress = mkOption {
+      type = types.str;
+      readOnly = true;
+      default =
+        if config.nixflix.vpn.enable && cfg.vpn.enable then
+          config.vpnNamespaces.wg.namespaceAddress
+        else
+          "127.0.0.1";
+      description = "Address for connecting to this service.";
+    };
+
     user = mkOption {
       type = types.str;
       default = serviceName;
@@ -243,7 +254,7 @@ in
       inherit hostname;
       inherit (cfg.reverseProxy) expose;
       inherit (cfg.config.hostConfig) port;
-      upstreamHost = cfg.config.hostConfig.bindAddress;
+      upstreamHost = cfg.connectionAddress;
       themeParkService = serviceBase;
     })
     {

--- a/modules/downloadarr/options.nix
+++ b/modules/downloadarr/options.nix
@@ -134,8 +134,8 @@ let
     dependencies.default = [ "sabnzbd-categories.service" ];
 
     host = {
-      default = config.nixflix.usenetClients.sabnzbd.settings.misc.host;
-      defaultText = literalExpression "config.nixflix.usenetClients.sabnzbd.settings.misc.host";
+      default = config.nixflix.usenetClients.sabnzbd.connectionAddress;
+      defaultText = literalExpression "config.nixflix.usenetClients.sabnzbd.connectionAddress";
     };
 
     port = {
@@ -180,8 +180,8 @@ let
     dependencies.default = [ "qbittorrent.service" ];
 
     host = {
-      default = config.nixflix.torrentClients.qbittorrent.serverConfig.Preferences.WebUI.Address;
-      defaultText = literalExpression "config.nixflix.torrentClients.qbittorrent.serverConfig.Preferences.WebUI.Address";
+      default = config.nixflix.torrentClients.qbittorrent.connectionAddress;
+      defaultText = literalExpression "config.nixflix.torrentClients.qbittorrent.connectionAddress";
     };
 
     port = {

--- a/modules/downloadarr/service.nix
+++ b/modules/downloadarr/service.nix
@@ -83,13 +83,17 @@ let
           RemainAfterExit = true;
           ExecStartPre =
             "${pkgs.curl}/bin/curl --retry 30 --retry-delay 2 --retry-connrefused -so /dev/null"
-            + " http://${serviceConfig.hostConfig.bindAddress}:${builtins.toString serviceConfig.hostConfig.port}${serviceConfig.hostConfig.urlBase}/api/${serviceConfig.apiVersion}/system/status";
+            + " http://${
+               config.nixflix.${serviceName}.connectionAddress
+             }:${builtins.toString serviceConfig.hostConfig.port}${serviceConfig.hostConfig.urlBase}/api/${serviceConfig.apiVersion}/system/status";
         };
 
         script = ''
           set -eu
 
-          BASE_URL="http://${serviceConfig.hostConfig.bindAddress}:${builtins.toString serviceConfig.hostConfig.port}${serviceConfig.hostConfig.urlBase}/api/${serviceConfig.apiVersion}"
+          BASE_URL="http://${
+            config.nixflix.${serviceName}.connectionAddress
+          }:${builtins.toString serviceConfig.hostConfig.port}${serviceConfig.hostConfig.urlBase}/api/${serviceConfig.apiVersion}"
 
           # Fetch all download client schemas
           echo "Fetching download client schemas..."

--- a/modules/jellyfin/brandingService.nix
+++ b/modules/jellyfin/brandingService.nix
@@ -21,9 +21,9 @@ let
 
   baseUrl =
     if cfg.network.baseUrl == "" then
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}"
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}"
     else
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
 
   waitForApiScript = import ./waitForApiScript.nix {
     inherit pkgs;

--- a/modules/jellyfin/encodingService.nix
+++ b/modules/jellyfin/encodingService.nix
@@ -19,9 +19,9 @@ let
 
   baseUrl =
     if cfg.network.baseUrl == "" then
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}"
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}"
     else
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
 
   waitForApiScript = import ./waitForApiScript.nix {
     inherit pkgs;

--- a/modules/jellyfin/librariesService.nix
+++ b/modules/jellyfin/librariesService.nix
@@ -41,9 +41,9 @@ let
 
   baseUrl =
     if cfg.network.baseUrl == "" then
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}"
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}"
     else
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
 
   waitForApiScript = import ./waitForApiScript.nix {
     inherit pkgs;

--- a/modules/jellyfin/options/default.nix
+++ b/modules/jellyfin/options/default.nix
@@ -130,6 +130,17 @@ in
         '';
       };
     };
+
+    connectionAddress = mkOption {
+      type = types.str;
+      readOnly = true;
+      default =
+        if config.nixflix.vpn.enable && config.nixflix.jellyfin.vpn.enable then
+          config.vpnNamespaces.wg.namespaceAddress
+        else
+          "127.0.0.1";
+      description = "Address for connecting to this service.";
+    };
   };
 
   config.assertions = [

--- a/modules/jellyfin/plugins/pluginsService.nix
+++ b/modules/jellyfin/plugins/pluginsService.nix
@@ -27,9 +27,9 @@ let
 
   baseUrl =
     if cfg.network.baseUrl == "" then
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}"
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}"
     else
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
 
   managedPlugins = filterAttrs (
     _name: pluginCfg: pluginCfg.package != null

--- a/modules/jellyfin/setupWizardService.nix
+++ b/modules/jellyfin/setupWizardService.nix
@@ -23,9 +23,9 @@ let
 
   baseUrl =
     if cfg.network.baseUrl == "" then
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}"
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}"
     else
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
 
   waitForApiScript = import ./waitForApiScript.nix {
     inherit pkgs;

--- a/modules/jellyfin/systemConfigService.nix
+++ b/modules/jellyfin/systemConfigService.nix
@@ -35,9 +35,9 @@ let
 
   baseUrl =
     if cfg.network.baseUrl == "" then
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}"
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}"
     else
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
 
   waitForApiScript = import ./waitForApiScript.nix {
     inherit pkgs;

--- a/modules/jellyfin/usersConfigService.nix
+++ b/modules/jellyfin/usersConfigService.nix
@@ -29,9 +29,9 @@ let
 
   baseUrl =
     if cfg.network.baseUrl == "" then
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}"
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}"
     else
-      "http://127.0.0.1:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
+      "http://${cfg.connectionAddress}:${toString cfg.network.internalHttpPort}/${cfg.network.baseUrl}";
 
   waitForApiScript = import ./waitForApiScript.nix {
     inherit pkgs;

--- a/modules/jellyfin/waitForApiScript.nix
+++ b/modules/jellyfin/waitForApiScript.nix
@@ -5,9 +5,9 @@
 let
   baseUrl =
     if jellyfinCfg.network.baseUrl == "" then
-      "http://127.0.0.1:${toString jellyfinCfg.network.internalHttpPort}"
+      "http://${jellyfinCfg.connectionAddress}:${toString jellyfinCfg.network.internalHttpPort}"
     else
-      "http://127.0.0.1:${toString jellyfinCfg.network.internalHttpPort}/${jellyfinCfg.network.baseUrl}";
+      "http://${jellyfinCfg.connectionAddress}:${toString jellyfinCfg.network.internalHttpPort}/${jellyfinCfg.network.baseUrl}";
 in
 pkgs.writeShellScript "jellyfin-wait-for-api" ''
   set -eu

--- a/modules/prowlarr/applications.nix
+++ b/modules/prowlarr/applications.nix
@@ -79,7 +79,7 @@ in
         script = ''
           set -eu
 
-          BASE_URL="http://${cfg.config.hostConfig.bindAddress}:${builtins.toString cfg.config.hostConfig.port}${cfg.config.hostConfig.urlBase}/api/${cfg.config.apiVersion}"
+          BASE_URL="http://${cfg.connectionAddress}:${builtins.toString cfg.config.hostConfig.port}${cfg.config.hostConfig.urlBase}/api/${cfg.config.apiVersion}"
 
           # Fetch all application schemas
           echo "Fetching application schemas..."

--- a/modules/prowlarr/default.nix
+++ b/modules/prowlarr/default.nix
@@ -27,8 +27,10 @@ let
       serviceBase = builtins.elemAt (splitString "-" serviceName) 0;
       implementationName = toUpper (substring 0 1 serviceBase) + substring 1 (-1) serviceBase;
 
-      baseUrl = "http://${serviceConfig.hostConfig.bindAddress}:${toString serviceConfig.hostConfig.port}${serviceConfig.hostConfig.urlBase}";
-      prowlarrUrl = "http://${nixflix.prowlarr.config.hostConfig.bindAddress}:${toString nixflix.prowlarr.config.hostConfig.port}${nixflix.prowlarr.config.hostConfig.urlBase}";
+      baseUrl = "http://${
+        nixflix.${serviceName}.connectionAddress
+      }:${toString serviceConfig.hostConfig.port}${serviceConfig.hostConfig.urlBase}";
+      prowlarrUrl = "http://${nixflix.prowlarr.connectionAddress}:${toString nixflix.prowlarr.config.hostConfig.port}${nixflix.prowlarr.config.hostConfig.urlBase}";
     in
     mkIf (nixflix.${serviceName}.enable or false) {
       name = displayName;

--- a/modules/prowlarr/indexerProxies.nix
+++ b/modules/prowlarr/indexerProxies.nix
@@ -94,7 +94,7 @@ in
         script = ''
           set -eu
 
-          BASE_URL="http://${cfg.config.hostConfig.bindAddress}:${builtins.toString cfg.config.hostConfig.port}${cfg.config.hostConfig.urlBase}/api/${cfg.config.apiVersion}"
+          BASE_URL="http://${cfg.connectionAddress}:${builtins.toString cfg.config.hostConfig.port}${cfg.config.hostConfig.urlBase}/api/${cfg.config.apiVersion}"
 
           # Fetch all indexer schemas
           echo "Fetching indexer proxy schemas..."

--- a/modules/prowlarr/indexers.nix
+++ b/modules/prowlarr/indexers.nix
@@ -93,7 +93,7 @@ in
         script = ''
           set -eu
 
-          BASE_URL="http://${cfg.config.hostConfig.bindAddress}:${builtins.toString cfg.config.hostConfig.port}${cfg.config.hostConfig.urlBase}/api/${cfg.config.apiVersion}"
+          BASE_URL="http://${cfg.connectionAddress}:${builtins.toString cfg.config.hostConfig.port}${cfg.config.hostConfig.urlBase}/api/${cfg.config.apiVersion}"
 
           # Fetch all indexer schemas
           echo "Fetching indexer schemas..."

--- a/modules/prowlarr/tags.nix
+++ b/modules/prowlarr/tags.nix
@@ -31,7 +31,7 @@ in
         script = ''
           set -eu
 
-          BASE_URL="http://${cfg.config.hostConfig.bindAddress}:${builtins.toString cfg.config.hostConfig.port}${cfg.config.hostConfig.urlBase}/api/${cfg.config.apiVersion}"
+          BASE_URL="http://${cfg.connectionAddress}:${builtins.toString cfg.config.hostConfig.port}${cfg.config.hostConfig.urlBase}/api/${cfg.config.apiVersion}"
 
           # Fetch existing tags
           echo "Fetching existing tags..."

--- a/modules/recyclarr/radarr.nix
+++ b/modules/recyclarr/radarr.nix
@@ -11,7 +11,7 @@ in
   ];
 
   nixflix.recyclarr.config.radarr.radarr = lib.mkIf config.nixflix.radarr.enable {
-    base_url = lib.mkDefault "http://${config.nixflix.radarr.config.hostConfig.bindAddress}:${toString config.nixflix.radarr.config.hostConfig.port}${toString config.nixflix.radarr.config.hostConfig.urlBase}";
+    base_url = lib.mkDefault "http://${config.nixflix.radarr.connectionAddress}:${toString config.nixflix.radarr.config.hostConfig.port}${toString config.nixflix.radarr.config.hostConfig.urlBase}";
     api_key = lib.mkDefault config.nixflix.radarr.config.apiKey;
     delete_old_custom_formats = lib.mkDefault true;
 

--- a/modules/recyclarr/sonarr-anime.nix
+++ b/modules/recyclarr/sonarr-anime.nix
@@ -8,7 +8,7 @@
   ];
 
   nixflix.recyclarr.config.sonarr.sonarr_anime = lib.mkIf config.nixflix.sonarr-anime.enable {
-    base_url = lib.mkDefault "http://${config.nixflix.sonarr-anime.config.hostConfig.bindAddress}:${toString config.nixflix.sonarr-anime.config.hostConfig.port}${toString config.nixflix.sonarr-anime.config.hostConfig.urlBase}";
+    base_url = lib.mkDefault "http://${config.nixflix.sonarr-anime.connectionAddress}:${toString config.nixflix.sonarr-anime.config.hostConfig.port}${toString config.nixflix.sonarr-anime.config.hostConfig.urlBase}";
     api_key = lib.mkDefault config.nixflix.sonarr-anime.config.apiKey;
     delete_old_custom_formats = lib.mkDefault true;
 

--- a/modules/recyclarr/sonarr.nix
+++ b/modules/recyclarr/sonarr.nix
@@ -11,7 +11,7 @@ in
   ];
 
   nixflix.recyclarr.config.sonarr.sonarr = lib.mkIf config.nixflix.sonarr.enable {
-    base_url = lib.mkDefault "http://${config.nixflix.sonarr.config.hostConfig.bindAddress}:${toString config.nixflix.sonarr.config.hostConfig.port}${toString config.nixflix.sonarr.config.hostConfig.urlBase}";
+    base_url = lib.mkDefault "http://${config.nixflix.sonarr.connectionAddress}:${toString config.nixflix.sonarr.config.hostConfig.port}${toString config.nixflix.sonarr.config.hostConfig.urlBase}";
     api_key = lib.mkDefault config.nixflix.sonarr.config.apiKey;
     delete_old_custom_formats = lib.mkDefault true;
 

--- a/modules/seerr/jellyfinService.nix
+++ b/modules/seerr/jellyfinService.nix
@@ -15,7 +15,7 @@ let
       cfg
       ;
   };
-  baseUrl = "http://127.0.0.1:${toString cfg.port}";
+  baseUrl = "http://${cfg.connectionAddress}:${toString cfg.port}";
 in
 {
   config = mkIf (nixflix.enable && cfg.enable) {

--- a/modules/seerr/librarySyncService.nix
+++ b/modules/seerr/librarySyncService.nix
@@ -15,7 +15,7 @@ let
       cfg
       ;
   };
-  baseUrl = "http://127.0.0.1:${toString cfg.port}";
+  baseUrl = "http://${cfg.connectionAddress}:${toString cfg.port}";
 in
 {
   config = mkIf (nixflix.enable && cfg.enable) {

--- a/modules/seerr/options/default.nix
+++ b/modules/seerr/options/default.nix
@@ -99,6 +99,17 @@ in
         '';
       };
     };
+
+    connectionAddress = mkOption {
+      type = types.str;
+      readOnly = true;
+      default =
+        if config.nixflix.vpn.enable && config.nixflix.seerr.vpn.enable then
+          config.vpnNamespaces.wg.namespaceAddress
+        else
+          "127.0.0.1";
+      description = "Address for connecting to this service.";
+    };
   };
 
   config.assertions = [

--- a/modules/seerr/options/jellyfin.nix
+++ b/modules/seerr/options/jellyfin.nix
@@ -40,7 +40,8 @@ in
 
     hostname = mkOption {
       type = types.str;
-      default = "127.0.0.1";
+      default = config.nixflix.jellyfin.connectionAddress;
+      defaultText = literalExpression "config.nixflix.jellyfin.connectionAddress";
       description = "Jellyfin server hostname";
     };
 

--- a/modules/seerr/options/radarr.nix
+++ b/modules/seerr/options/radarr.nix
@@ -95,7 +95,7 @@ let
 
   defaultInstance = optionalAttrs (config.nixflix.radarr.enable or false) {
     Radarr = {
-      hostname = config.nixflix.radarr.config.hostConfig.bindAddress;
+      hostname = config.nixflix.radarr.connectionAddress;
       port = config.nixflix.radarr.config.hostConfig.port or 7878;
       inherit (config.nixflix.radarr.config) apiKey;
       baseUrl = config.nixflix.radarr.config.hostConfig.urlBase;

--- a/modules/seerr/options/sonarr.nix
+++ b/modules/seerr/options/sonarr.nix
@@ -125,7 +125,7 @@ let
   defaultInstances =
     (optionalAttrs (config.nixflix.sonarr.enable or false) {
       Sonarr = {
-        hostname = config.nixflix.sonarr.config.hostConfig.bindAddress;
+        hostname = config.nixflix.sonarr.connectionAddress;
         port = config.nixflix.sonarr.config.hostConfig.port or 8989;
         inherit (config.nixflix.sonarr.config) apiKey;
         baseUrl = config.nixflix.sonarr.config.hostConfig.urlBase;
@@ -143,7 +143,7 @@ let
     })
     // (optionalAttrs (config.nixflix.sonarr-anime.enable or false) {
       "Sonarr Anime" = {
-        hostname = config.nixflix.sonarr-anime.config.hostConfig.bindAddress;
+        hostname = config.nixflix."sonarr-anime".connectionAddress;
         port = config.nixflix.sonarr-anime.config.hostConfig.port or 8990;
         inherit (config.nixflix.sonarr-anime.config) apiKey;
         baseUrl = config.nixflix.sonarr-anime.config.hostConfig.urlBase;

--- a/modules/seerr/radarrService.nix
+++ b/modules/seerr/radarrService.nix
@@ -16,7 +16,7 @@ let
       cfg
       ;
   };
-  baseUrl = "http://127.0.0.1:${toString cfg.port}";
+  baseUrl = "http://${cfg.connectionAddress}:${toString cfg.port}";
 
   sanitizeName = name: builtins.replaceStrings [ " " "-" ] [ "_" "_" ] name;
 

--- a/modules/seerr/setupService.nix
+++ b/modules/seerr/setupService.nix
@@ -17,7 +17,7 @@ let
       cfg
       ;
   };
-  baseUrl = "http://127.0.0.1:${toString cfg.port}";
+  baseUrl = "http://${cfg.connectionAddress}:${toString cfg.port}";
   jqSetupSecrets = secrets.mkJqSecretArgs {
     password = cfg.jellyfin.adminPassword;
   };

--- a/modules/seerr/sonarrService.nix
+++ b/modules/seerr/sonarrService.nix
@@ -16,7 +16,7 @@ let
       cfg
       ;
   };
-  baseUrl = "http://127.0.0.1:${toString cfg.port}";
+  baseUrl = "http://${cfg.connectionAddress}:${toString cfg.port}";
 
   sanitizeName = name: builtins.replaceStrings [ " " "-" ] [ "_" "_" ] name;
 

--- a/modules/seerr/userSettingsService.nix
+++ b/modules/seerr/userSettingsService.nix
@@ -15,7 +15,7 @@ let
       cfg
       ;
   };
-  baseUrl = "http://127.0.0.1:${toString cfg.port}";
+  baseUrl = "http://${cfg.connectionAddress}:${toString cfg.port}";
   userSettings = cfg.settings.users;
 in
 {

--- a/modules/torrentClients/qbittorrent.nix
+++ b/modules/torrentClients/qbittorrent.nix
@@ -153,10 +153,23 @@ in
             default =
               if config.nixflix.vpn.enable && cfg.vpn.enable then
                 config.vpnNamespaces.wg.namespaceAddress
+              else if config.nixflix.reverseProxy.enable then
+                "127.0.0.1"
               else
-                "127.0.0.1";
+                "*";
             description = "Bind address for the WebUI";
           };
+        };
+
+        connectionAddress = mkOption {
+          type = types.str;
+          readOnly = true;
+          default =
+            if config.nixflix.vpn.enable && cfg.vpn.enable then
+              config.vpnNamespaces.wg.namespaceAddress
+            else
+              "127.0.0.1";
+          description = "Address for connecting to this service.";
         };
       };
     };
@@ -168,7 +181,7 @@ in
       inherit hostname;
       inherit (cfg.reverseProxy) expose;
       port = service.webuiPort;
-      upstreamHost = cfg.serverConfig.Preferences.WebUI.Address;
+      upstreamHost = cfg.connectionAddress;
       themeParkService = "qbittorrent";
       stripHeaders = [
         "x-webkit-csp"
@@ -186,6 +199,7 @@ in
 
       services.qbittorrent = builtins.removeAttrs cfg [
         "categories"
+        "connectionAddress"
         "downloadsDir"
         "password"
         "reverseProxy"

--- a/modules/usenetClients/sabnzbd/categoriesService.nix
+++ b/modules/usenetClients/sabnzbd/categoriesService.nix
@@ -31,7 +31,7 @@ in
       script = ''
         set -euo pipefail
 
-        BASE_URL="http://${cfg.settings.misc.host}:${toString cfg.settings.misc.port}${cfg.settings.misc.url_base}"
+        BASE_URL="http://${cfg.connectionAddress}:${toString cfg.settings.misc.port}${cfg.settings.misc.url_base}"
 
         # Function to make API calls
         api_call() {

--- a/modules/usenetClients/sabnzbd/default.nix
+++ b/modules/usenetClients/sabnzbd/default.nix
@@ -99,6 +99,17 @@ in
         '';
       };
     };
+
+    connectionAddress = mkOption {
+      type = types.str;
+      readOnly = true;
+      default =
+        if config.nixflix.vpn.enable && cfg.vpn.enable then
+          config.vpnNamespaces.wg.namespaceAddress
+        else
+          "127.0.0.1";
+      description = "Address for connecting to this service.";
+    };
   };
 
   config = mkIf (config.nixflix.enable && cfg.enable) (mkMerge [
@@ -106,7 +117,7 @@ in
       inherit hostname;
       inherit (cfg.reverseProxy) expose;
       inherit (cfg.settings.misc) port;
-      upstreamHost = cfg.settings.misc.host;
+      upstreamHost = cfg.connectionAddress;
       themeParkService = "sabnzbd";
       websocketUpgrade = true;
     })

--- a/tests/unit-tests/default.nix
+++ b/tests/unit-tests/default.nix
@@ -528,6 +528,68 @@ in
       echo 'PASS: jellyfin-integration' > $out
     '';
 
+  download-clients-no-reverse-proxy =
+    let
+      config = evalConfig [
+        {
+          nixflix = {
+            enable = true;
+            nginx.enable = false;
+
+            radarr = {
+              enable = true;
+              config = {
+                hostConfig = {
+                  port = 7878;
+                  username = "admin";
+                  password._secret = "/run/secrets/radarr-pass";
+                };
+                apiKey._secret = "/run/secrets/radarr-api";
+                rootFolders = [ { path = "/media/movies"; } ];
+              };
+            };
+
+            usenetClients.sabnzbd = {
+              enable = true;
+              settings.misc = {
+                api_key._secret = pkgs.writeText "sabnzbd-apikey" "testapikey123456789abcdef";
+                nzb_key._secret = pkgs.writeText "sabnzbd-nzbkey" "testnzbkey123456789abcdef";
+                port = 8080;
+                url_base = "/sabnzbd";
+              };
+            };
+          };
+        }
+      ];
+      radarrCfg = config.config.nixflix.radarr;
+      sabnzbdCfg = config.config.nixflix.usenetClients.sabnzbd;
+      downloadClientsService = config.config.systemd.services."radarr-downloadclients";
+    in
+    pkgs.runCommand "unit-test-download-clients-no-reverse-proxy" { } ''
+      ${check "radarr bindAddress is 0.0.0.0 when nginx is disabled" (
+        radarrCfg.config.hostConfig.bindAddress == "0.0.0.0"
+      )}
+      ${check "radarr connectionAddress is 127.0.0.1 (not 0.0.0.0)" (
+        radarrCfg.connectionAddress == "127.0.0.1"
+      )}
+      ${check "sabnzbd connectionAddress is 127.0.0.1 (not 0.0.0.0)" (
+        sabnzbdCfg.connectionAddress == "127.0.0.1"
+      )}
+      ${check "radarr-downloadclients ExecStartPre uses connectionAddress" (
+        lib.hasInfix "127.0.0.1" downloadClientsService.serviceConfig.ExecStartPre
+      )}
+      ${check "radarr-downloadclients ExecStartPre does not use 0.0.0.0" (
+        !lib.hasInfix "0.0.0.0" downloadClientsService.serviceConfig.ExecStartPre
+      )}
+      ${check "radarr-downloadclients script uses connectionAddress" (
+        lib.hasInfix "127.0.0.1" downloadClientsService.script
+      )}
+      ${check "radarr-downloadclients script does not use 0.0.0.0" (
+        !lib.hasInfix "0.0.0.0" downloadClientsService.script
+      )}
+      echo 'PASS: download-clients-no-reverse-proxy' > $out
+    '';
+
   jellyfin-subtitles =
     let
       config = evalConfig [


### PR DESCRIPTION
Resolves #194

Introduce `connectionAddress` concept that derives the address other services should be using when integrating with the target service. This value is dependent on whether or not VPN confinement is enabled for that service.

This also add bind address logic for each service. If in confinement, bind the the VPN namespace. Else if the reverse proxy is enabled, bind to the loopback address. Otherwise bind to all interfaces.