### PR TITLE
prowlarr-indexers service - check for different names for apiKey

### DIFF
--- a/modules/prowlarr/indexers.nix
+++ b/modules/prowlarr/indexers.nix
@@ -180,7 +180,7 @@ in
                   ${jqSecrets.flagsString} \
                   --argjson overrides "$overrides" '
                     .fields[] |= (
-                      if .name == "apiKey" and ${jqSecrets.refs.apiKey} != "" then .value = ${jqSecrets.refs.apiKey}
+                      if .name == "apiKey" or .name == "apikey" and ${jqSecrets.refs.apiKey} != "" then .value = ${jqSecrets.refs.apiKey}
                       elif .name == "username" and ${jqSecrets.refs.username} != "" then .value = ${jqSecrets.refs.username}
                       elif .name == "password" and ${jqSecrets.refs.password} != "" then .value = ${jqSecrets.refs.password}
                       else .


### PR DESCRIPTION
Fixes #209

Currently, I'm explicitly testing for any known variations of the field name, i.e. `if .name == "apiKey" or .name == "apikey"`. This fixes the issue in #209, however if any other indexers in prowlarr have a different name for the api key field they would have to be manually added to this condition.

Alternatively, a regex could be used both to ignore case as well as test for other variations such as "api_key" - `.name | test("^(?:apikey|api_key)$"; "i")`

I don't really know how much variation there might be in prowlarr indexer configurations, so I'm not sure which approach is better here.