### PR TITLE
systemd sandbox hardening for arr services

### DIFF
--- a/modules/arr-common/delayProfiles.nix
+++ b/modules/arr-common/delayProfiles.nix
@@ -6,6 +6,7 @@
 with lib;
 let
   mkSecureCurl = import ../../lib/mk-secure-curl.nix { inherit lib pkgs; };
+  apiClientSandbox = import ./mkApiClientSandbox.nix;
   capitalizedName =
     lib.toUpper (builtins.substring 0 1 serviceName) + builtins.substring 1 (-1) serviceName;
 
@@ -123,7 +124,8 @@ in
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-    };
+    }
+    // apiClientSandbox;
 
     script =
       let

--- a/modules/arr-common/hostConfig.nix
+++ b/modules/arr-common/hostConfig.nix
@@ -10,6 +10,7 @@ let
   secrets = import ../../lib/secrets { inherit lib; };
   mkSecureCurl = import ../../lib/mk-secure-curl.nix { inherit lib pkgs; };
   mkWaitForApiScript = import ./mkWaitForApiScript.nix { inherit lib pkgs; };
+  apiClientSandbox = import ./mkApiClientSandbox.nix;
   capitalizedName =
     lib.toUpper (builtins.substring 0 1 serviceName) + builtins.substring 1 (-1) serviceName;
 in
@@ -46,7 +47,8 @@ in
         RemainAfterExit = true;
         ExecStartPre = mkWaitForApiScript serviceName serviceConfig;
         ExecStartPost = mkWaitForApiScript serviceName serviceConfig;
-      };
+      }
+      // apiClientSandbox;
 
       script = ''
         set -eu

--- a/modules/arr-common/mkApiClientSandbox.nix
+++ b/modules/arr-common/mkApiClientSandbox.nix
@@ -1,0 +1,35 @@
+# Sandbox profile for oneshot services that only make outbound HTTP API calls
+# and read secret files. No filesystem writes are needed, so ProtectSystem=strict
+# is safe. The service still runs as root because secret files are root-owned;
+# that constraint goes away once LoadCredential (nixflix-a5v) is implemented.
+{
+  PrivateTmp = true;
+  ProtectHome = true;
+  ProtectSystem = "strict";
+  NoNewPrivileges = true;
+  RestrictNamespaces = true;
+  CapabilityBoundingSet = "";
+  AmbientCapabilities = "";
+  ProtectProc = "invisible";
+  ProcSubset = "pid";
+  ProtectKernelTunables = true;
+  ProtectKernelModules = true;
+  ProtectKernelLogs = true;
+  ProtectControlGroups = true;
+  LockPersonality = true;
+  RestrictRealtime = true;
+  RestrictSUIDSGID = true;
+  RestrictAddressFamilies = [
+    "AF_UNIX"
+    "AF_INET"
+    "AF_INET6"
+  ];
+  SystemCallArchitectures = "native";
+  SystemCallFilter = [
+    "~@debug"
+    "~@module"
+    "~@raw-io"
+    "~@reboot"
+    "~@swap"
+  ];
+}

--- a/modules/arr-common/mkArrServiceModule.nix
+++ b/modules/arr-common/mkArrServiceModule.nix
@@ -444,9 +444,46 @@ in
             User = cfg.user;
             Group = cfg.group;
             ExecStart = "${getExe cfg.package} -nobrowser -data='${cfg.dataDir}'";
+            # '+' prefix runs as root; NoNewPrivileges does not apply to it
             ExecStartPost = "+" + (mkWaitForApiScript serviceName cfg.config);
             Restart = "on-failure";
             UMask = "0002";
+
+            # RestrictNamespaces: safe with vpnConfinement (systemd resolves NetworkNamespacePath before exec)
+            NoNewPrivileges = true;
+            PrivateTmp = true;
+            ProtectHome = true;
+            ProtectSystem = "strict";
+            CapabilityBoundingSet = "";
+            AmbientCapabilities = "";
+            ProtectProc = "invisible";
+            ProcSubset = "pid";
+            ReadWritePaths = [
+              cfg.dataDir
+            ]
+            ++ optionals usesMediaDirs (cfg.mediaDirs ++ [ config.nixflix.downloadsDir ]);
+            RestrictNamespaces = true;
+            PrivateDevices = true;
+            SystemCallFilter = [
+              "~@debug"
+              "~@module"
+              "~@raw-io"
+              "~@reboot"
+              "~@swap"
+            ];
+            ProtectKernelTunables = true;
+            ProtectKernelModules = true;
+            ProtectKernelLogs = true;
+            ProtectControlGroups = true;
+            LockPersonality = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            RestrictAddressFamilies = [
+              "AF_UNIX"
+              "AF_INET"
+              "AF_INET6"
+            ];
+            SystemCallArchitectures = "native";
           }
           // optionalAttrs (cfg.config.apiKey != null && cfg.config.hostConfig.password != null) {
             EnvironmentFile = "/run/${serviceName}/env";

--- a/modules/arr-common/mkArrServiceModule.nix
+++ b/modules/arr-common/mkArrServiceModule.nix
@@ -36,6 +36,16 @@ let
   hostname = "${cfg.subdomain}.${config.nixflix.reverseProxy.domain}";
 
   serviceBase = builtins.elemAt (splitString "-" serviceName) 0;
+  apiKeyEnvVar = toUpper serviceBase + "__AUTH__APIKEY";
+  apiKeyIsSecretRef = cfg.config.apiKey != null && secrets.isSecretRef cfg.config.apiKey;
+  credentialPath = "/run/credentials/${serviceName}.service/apiKey";
+  waitConfig =
+    cfg.config
+    // optionalAttrs apiKeyIsSecretRef {
+      apiKey = {
+        _secret = credentialPath;
+      };
+    };
 
   mkServarrSettingsEnvVars =
     name: settings:
@@ -424,17 +434,11 @@ in
             "nixflix-setup-dirs.service"
           ]
           ++ config.nixflix.serviceDependencies
-          ++ (optional (
-            cfg.config.apiKey != null && cfg.config.hostConfig.password != null
-          ) "${serviceName}-env.service")
           ++ (optional config.nixflix.postgres.enable "postgresql-ready.target");
           requires = [
             "nixflix-setup-dirs.service"
           ]
           ++ config.nixflix.serviceDependencies
-          ++ (optional (
-            cfg.config.apiKey != null && cfg.config.hostConfig.password != null
-          ) "${serviceName}-env.service")
           ++ (optional config.nixflix.postgres.enable "postgresql-ready.target");
           wants = [ ];
           wantedBy = [ "multi-user.target" ];
@@ -443,9 +447,15 @@ in
             Type = "simple";
             User = cfg.user;
             Group = cfg.group;
-            ExecStart = "${getExe cfg.package} -nobrowser -data='${cfg.dataDir}'";
-            # '+' prefix runs as root; NoNewPrivileges does not apply to it
-            ExecStartPost = "+" + (mkWaitForApiScript serviceName cfg.config);
+            ExecStart =
+              if apiKeyIsSecretRef then
+                pkgs.writeShellScript "${serviceName}-start" ''
+                  export ${apiKeyEnvVar}="$(cat ${credentialPath})"
+                  exec ${getExe cfg.package} -nobrowser -data='${cfg.dataDir}'
+                ''
+              else
+                "${getExe cfg.package} -nobrowser -data='${cfg.dataDir}'";
+            ExecStartPost = mkWaitForApiScript serviceName waitConfig;
             Restart = "on-failure";
             UMask = "0002";
 
@@ -485,32 +495,15 @@ in
             ];
             SystemCallArchitectures = "native";
           }
-          // optionalAttrs (cfg.config.apiKey != null && cfg.config.hostConfig.password != null) {
-            EnvironmentFile = "/run/${serviceName}/env";
+          // optionalAttrs apiKeyIsSecretRef {
+            LoadCredential = [ "apiKey:${toString cfg.config.apiKey._secret}" ];
+          }
+          // optionalAttrs (cfg.config.apiKey != null && !apiKeyIsSecretRef) {
+            environment.${apiKeyEnvVar} = toString cfg.config.apiKey;
           };
         };
       }
       // optionalAttrs (cfg.config.apiKey != null && cfg.config.hostConfig.password != null) {
-        "${serviceName}-env" = {
-          description = "Setup ${capitalizedName} environment file";
-          wantedBy = [ "${serviceName}.service" ];
-          before = [ "${serviceName}.service" ];
-
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-          };
-
-          script = ''
-            mkdir -p /run/${serviceName}
-            echo "${
-              toUpper serviceBase + "__AUTH__APIKEY"
-            }=${secrets.toShellValue cfg.config.apiKey}" > /run/${serviceName}/env
-            chown ${cfg.user}:${cfg.group} /run/${serviceName}/env
-            chmod 0400 /run/${serviceName}/env
-          '';
-        };
-
         "${serviceName}-config" = hostConfig.mkService cfg.config;
       }
       // optionalAttrs (usesMediaDirs && cfg.config.apiKey != null && cfg.config.rootFolders != [ ]) {

--- a/modules/arr-common/mkArrServiceModule.nix
+++ b/modules/arr-common/mkArrServiceModule.nix
@@ -447,6 +447,7 @@ in
             Type = "simple";
             User = cfg.user;
             Group = cfg.group;
+            SupplementaryGroups = optionals usesMediaDirs [ globals.libraryOwner.group ];
             ExecStart =
               if apiKeyIsSecretRef then
                 pkgs.writeShellScript "${serviceName}-start" ''

--- a/modules/arr-common/rootFolders.nix
+++ b/modules/arr-common/rootFolders.nix
@@ -7,6 +7,7 @@
 with lib;
 let
   mkSecureCurl = import ../../lib/mk-secure-curl.nix { inherit lib pkgs; };
+  apiClientSandbox = import ./mkApiClientSandbox.nix;
   capitalizedName =
     lib.toUpper (builtins.substring 0 1 serviceName) + builtins.substring 1 (-1) serviceName;
 in
@@ -34,7 +35,8 @@ in
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-    };
+    }
+    // apiClientSandbox;
 
     script = ''
       set -eu

--- a/modules/downloadarr/service.nix
+++ b/modules/downloadarr/service.nix
@@ -8,6 +8,7 @@ with lib;
 let
   secrets = import ../../lib/secrets { inherit lib; };
   mkSecureCurl = import ../../lib/mk-secure-curl.nix { inherit lib pkgs; };
+  apiClientSandbox = import ../arr-common/mkApiClientSandbox.nix;
 
   cfg = config.nixflix.downloadarr;
 
@@ -79,14 +80,15 @@ let
         wantedBy = [ "multi-user.target" ];
 
         serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          ExecStartPre =
-            "${pkgs.curl}/bin/curl --retry 30 --retry-delay 2 --retry-connrefused -so /dev/null"
-            + " http://${
-               config.nixflix.${serviceName}.connectionAddress
-             }:${builtins.toString serviceConfig.hostConfig.port}${serviceConfig.hostConfig.urlBase}/api/${serviceConfig.apiVersion}/system/status";
-        };
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStartPre =
+              "${pkgs.curl}/bin/curl --retry 30 --retry-delay 2 --retry-connrefused -so /dev/null"
+              + " http://${
+                 config.nixflix.${serviceName}.connectionAddress
+               }:${builtins.toString serviceConfig.hostConfig.port}${serviceConfig.hostConfig.urlBase}/api/${serviceConfig.apiVersion}/system/status";
+          }
+          // apiClientSandbox;
 
         script = ''
           set -eu

--- a/modules/downloadarr/service.nix
+++ b/modules/downloadarr/service.nix
@@ -80,15 +80,15 @@ let
         wantedBy = [ "multi-user.target" ];
 
         serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-            ExecStartPre =
-              "${pkgs.curl}/bin/curl --retry 30 --retry-delay 2 --retry-connrefused -so /dev/null"
-              + " http://${
-                 config.nixflix.${serviceName}.connectionAddress
-               }:${builtins.toString serviceConfig.hostConfig.port}${serviceConfig.hostConfig.urlBase}/api/${serviceConfig.apiVersion}/system/status";
-          }
-          // apiClientSandbox;
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStartPre =
+            "${pkgs.curl}/bin/curl --retry 30 --retry-delay 2 --retry-connrefused -so /dev/null"
+            + " http://${
+               config.nixflix.${serviceName}.connectionAddress
+             }:${builtins.toString serviceConfig.hostConfig.port}${serviceConfig.hostConfig.urlBase}/api/${serviceConfig.apiVersion}/system/status";
+        }
+        // apiClientSandbox;
 
         script = ''
           set -eu

--- a/tests/unit-tests/default.nix
+++ b/tests/unit-tests/default.nix
@@ -783,6 +783,9 @@ in
       ${check "SystemCallFilter blocks @debug" (builtins.elem "~@debug" svc.SystemCallFilter)}
       ${check "SystemCallFilter blocks @module" (builtins.elem "~@module" svc.SystemCallFilter)}
       ${check "SystemCallFilter blocks @reboot" (builtins.elem "~@reboot" svc.SystemCallFilter)}
+      ${check "SupplementaryGroups includes libraryOwner group" (
+        builtins.elem config.config.nixflix.globals.libraryOwner.group svc.SupplementaryGroups
+      )}
       echo 'PASS: arr-sandbox-directives' > $out
     '';
 
@@ -901,6 +904,9 @@ in
       ${check "prowlarr ReadWritePaths includes dataDir" (builtins.elem dataDir svc.ReadWritePaths)}
       ${check "prowlarr ReadWritePaths excludes downloadsDir" (
         !builtins.elem downloadsDir svc.ReadWritePaths
+      )}
+      ${check "prowlarr has no SupplementaryGroups" (
+        !(svc ? SupplementaryGroups) || svc.SupplementaryGroups == [ ]
       )}
       echo 'PASS: arr-sandbox-prowlarr-read-write-paths' > $out
     '';

--- a/tests/unit-tests/default.nix
+++ b/tests/unit-tests/default.nix
@@ -780,7 +780,63 @@ in
       ${check "ReadWritePaths includes dataDir" (builtins.elem dataDir svc.ReadWritePaths)}
       ${check "ReadWritePaths includes mediaDirs" (builtins.elem "/media/tv" svc.ReadWritePaths)}
       ${check "ReadWritePaths includes downloadsDir" (builtins.elem downloadsDir svc.ReadWritePaths)}
+      ${check "SystemCallFilter blocks @debug" (builtins.elem "~@debug" svc.SystemCallFilter)}
+      ${check "SystemCallFilter blocks @module" (builtins.elem "~@module" svc.SystemCallFilter)}
+      ${check "SystemCallFilter blocks @reboot" (builtins.elem "~@reboot" svc.SystemCallFilter)}
       echo 'PASS: arr-sandbox-directives' > $out
+    '';
+
+  # Verify sandbox directives are present on setup oneshot services
+  arr-sandbox-setup-services =
+    let
+      config = evalConfig [
+        {
+          nixflix = {
+            enable = true;
+            sonarr = {
+              enable = true;
+              mediaDirs = [ "/media/tv" ];
+              config = {
+                apiKey._secret = "/run/secrets/sonarr-api";
+                hostConfig = {
+                  port = 8989;
+                  username = "admin";
+                  password._secret = "/run/secrets/sonarr-pass";
+                };
+                rootFolders = [ { path = "/media/tv"; } ];
+              };
+            };
+          };
+        }
+      ];
+      configSvc = config.config.systemd.services.sonarr-config.serviceConfig;
+      rootfoldersSvc = config.config.systemd.services.sonarr-rootfolders.serviceConfig;
+      delayprofilesSvc = config.config.systemd.services.sonarr-delayprofiles.serviceConfig;
+    in
+    pkgs.runCommand "unit-test-arr-sandbox-setup-services" { } ''
+      ${check "sonarr-config ProtectSystem=strict" (configSvc.ProtectSystem == "strict")}
+      ${check "sonarr-config NoNewPrivileges" configSvc.NoNewPrivileges}
+      ${check "sonarr-config PrivateTmp" configSvc.PrivateTmp}
+      ${check "sonarr-config CapabilityBoundingSet empty" (configSvc.CapabilityBoundingSet == "")}
+      ${check "sonarr-config RestrictNamespaces" configSvc.RestrictNamespaces}
+
+      ${check "sonarr-rootfolders ProtectSystem=strict" (rootfoldersSvc.ProtectSystem == "strict")}
+      ${check "sonarr-rootfolders NoNewPrivileges" rootfoldersSvc.NoNewPrivileges}
+      ${check "sonarr-rootfolders PrivateTmp" rootfoldersSvc.PrivateTmp}
+      ${check "sonarr-rootfolders CapabilityBoundingSet empty" (
+        rootfoldersSvc.CapabilityBoundingSet == ""
+      )}
+      ${check "sonarr-rootfolders RestrictNamespaces" rootfoldersSvc.RestrictNamespaces}
+
+      ${check "sonarr-delayprofiles ProtectSystem=strict" (delayprofilesSvc.ProtectSystem == "strict")}
+      ${check "sonarr-delayprofiles NoNewPrivileges" delayprofilesSvc.NoNewPrivileges}
+      ${check "sonarr-delayprofiles PrivateTmp" delayprofilesSvc.PrivateTmp}
+      ${check "sonarr-delayprofiles CapabilityBoundingSet empty" (
+        delayprofilesSvc.CapabilityBoundingSet == ""
+      )}
+      ${check "sonarr-delayprofiles RestrictNamespaces" delayprofilesSvc.RestrictNamespaces}
+
+      echo 'PASS: arr-sandbox-setup-services' > $out
     '';
 
   # Prowlarr (usesMediaDirs=false) should only have dataDir in ReadWritePaths

--- a/tests/unit-tests/default.nix
+++ b/tests/unit-tests/default.nix
@@ -740,4 +740,79 @@ in
 
       echo 'PASS: jellyfin-subtitles' > $out
     '';
+
+  # Verify sandbox directives are present on arr services that use media dirs (sonarr as representative)
+  arr-sandbox-directives =
+    let
+      config = evalConfig [
+        {
+          nixflix = {
+            enable = true;
+            sonarr = {
+              enable = true;
+              mediaDirs = [ "/media/tv" ];
+              config = {
+                apiKey._secret = "/run/secrets/sonarr-api";
+                hostConfig = {
+                  port = 8989;
+                  username = "admin";
+                  password._secret = "/run/secrets/sonarr-pass";
+                };
+              };
+            };
+          };
+        }
+      ];
+      svc = config.config.systemd.services.sonarr.serviceConfig;
+      dataDir = config.config.nixflix.sonarr.dataDir;
+      downloadsDir = config.config.nixflix.downloadsDir;
+    in
+    pkgs.runCommand "unit-test-arr-sandbox-directives" { } ''
+      ${check "ProtectSystem=strict" (svc.ProtectSystem == "strict")}
+      ${check "NoNewPrivileges" svc.NoNewPrivileges}
+      ${check "PrivateTmp" svc.PrivateTmp}
+      ${check "ProtectHome" svc.ProtectHome}
+      ${check "RestrictNamespaces" svc.RestrictNamespaces}
+      ${check "CapabilityBoundingSet empty" (svc.CapabilityBoundingSet == "")}
+      ${check "AmbientCapabilities empty" (svc.AmbientCapabilities == "")}
+      ${check "ProtectProc=invisible" (svc.ProtectProc == "invisible")}
+      ${check "ProcSubset=pid" (svc.ProcSubset == "pid")}
+      ${check "ReadWritePaths includes dataDir" (builtins.elem dataDir svc.ReadWritePaths)}
+      ${check "ReadWritePaths includes mediaDirs" (builtins.elem "/media/tv" svc.ReadWritePaths)}
+      ${check "ReadWritePaths includes downloadsDir" (builtins.elem downloadsDir svc.ReadWritePaths)}
+      echo 'PASS: arr-sandbox-directives' > $out
+    '';
+
+  # Prowlarr (usesMediaDirs=false) should only have dataDir in ReadWritePaths
+  arr-sandbox-prowlarr-read-write-paths =
+    let
+      config = evalConfig [
+        {
+          nixflix = {
+            enable = true;
+            prowlarr = {
+              enable = true;
+              config = {
+                apiKey._secret = "/run/secrets/prowlarr-api";
+                hostConfig = {
+                  port = 9696;
+                  username = "admin";
+                  password._secret = "/run/secrets/prowlarr-pass";
+                };
+              };
+            };
+          };
+        }
+      ];
+      svc = config.config.systemd.services.prowlarr.serviceConfig;
+      dataDir = config.config.nixflix.prowlarr.dataDir;
+      downloadsDir = config.config.nixflix.downloadsDir;
+    in
+    pkgs.runCommand "unit-test-arr-sandbox-prowlarr-read-write-paths" { } ''
+      ${check "prowlarr ReadWritePaths includes dataDir" (builtins.elem dataDir svc.ReadWritePaths)}
+      ${check "prowlarr ReadWritePaths excludes downloadsDir" (
+        !builtins.elem downloadsDir svc.ReadWritePaths
+      )}
+      echo 'PASS: arr-sandbox-prowlarr-read-write-paths' > $out
+    '';
 }

--- a/tests/unit-tests/default.nix
+++ b/tests/unit-tests/default.nix
@@ -839,6 +839,39 @@ in
       echo 'PASS: arr-sandbox-setup-services' > $out
     '';
 
+  # LoadCredential replaces the old -env root service; verify the generated unit
+  arr-load-credential =
+    let
+      config = evalConfig [
+        {
+          nixflix = {
+            enable = true;
+            sonarr = {
+              enable = true;
+              config = {
+                apiKey._secret = "/run/secrets/sonarr-api";
+                hostConfig = {
+                  port = 8989;
+                  username = "admin";
+                  password._secret = "/run/secrets/sonarr-pass";
+                };
+              };
+            };
+          };
+        }
+      ];
+      services = config.config.systemd.services;
+      svc = services.sonarr.serviceConfig;
+    in
+    pkgs.runCommand "unit-test-arr-load-credential" { } ''
+      ${check "sonarr-env service no longer exists" (!services ? sonarr-env)}
+      ${check "LoadCredential set for secret-ref apiKey" (
+        builtins.elem "apiKey:/run/secrets/sonarr-api" svc.LoadCredential
+      )}
+      ${check "no EnvironmentFile" (!svc ? EnvironmentFile)}
+      echo 'PASS: arr-load-credential' > $out
+    '';
+
   # Prowlarr (usesMediaDirs=false) should only have dataDir in ReadWritePaths
   arr-sandbox-prowlarr-read-write-paths =
     let

--- a/tests/vm-tests/sonarr-basic.nix
+++ b/tests/vm-tests/sonarr-basic.nix
@@ -176,5 +176,15 @@ pkgsUnfree.testers.runNixOSTest {
 
     # Verify the service is running under the correct user
     machine.succeed("pgrep -u testuser Sonarr")
+
+    # Verify sandbox directives are active at the kernel level
+    machine.succeed("systemctl show sonarr --property=ProtectSystem | grep -q 'ProtectSystem=strict'")
+    machine.succeed("systemctl show sonarr --property=NoNewPrivileges | grep -q 'NoNewPrivileges=yes'")
+    machine.succeed("systemctl show sonarr --property=PrivateTmp | grep -q 'PrivateTmp=yes'")
+    machine.succeed("systemctl show sonarr --property=ProtectHome | grep -q 'ProtectHome=yes'")
+    machine.succeed("systemctl show sonarr --property=RestrictNamespaces | grep -q 'RestrictNamespaces=yes'")
+    machine.succeed("systemctl show sonarr --property=ProtectProc | grep -q 'ProtectProc=invisible'")
+    machine.succeed("systemctl show sonarr --property=ProcSubset | grep -q 'ProcSubset=pid'")
+    print("Sandbox directives verified active")
   '';
 }


### PR DESCRIPTION
- Harden arr services with systemd sandbox directives, scoped read-write paths, and syscall filtering
- Sandbox arr setup oneshot services via shared `mkApiClientSandbox` attrset
- Replace root-owned env file pattern with `LoadCredential`
- Ensure arr services have group access to media dirs and download client files