### PR TITLE
qbittorrent: depend on nixflix.serviceDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- qBittorrent potentially starting before `nixflix.serviceDependencies` and thus losing track of downloaded files, lest a recheck was manually forced.
+
 ### Added
 
 - Starr app Media Management API configuration ([#221](https://github.com/kiriwalawren/nixflix/pull/221)).

--- a/modules/torrentClients/qbittorrent.nix
+++ b/modules/torrentClients/qbittorrent.nix
@@ -250,8 +250,8 @@ in
       };
 
       systemd.services.qbittorrent = {
-        after = [ "nixflix-setup-dirs.service" ];
-        requires = [ "nixflix-setup-dirs.service" ];
+        after = [ "nixflix-setup-dirs.service" ] ++ config.nixflix.serviceDependencies;
+        requires = [ "nixflix-setup-dirs.service" ] ++ config.nixflix.serviceDependencies;
         preStart = lib.mkIf (cfg.categories != { }) (
           lib.mkAfter ''
             cp -f '${categoriesFile}' '${configPath}/categories.json'


### PR DESCRIPTION
With this change, one can add some `"downloads-dir.mount"` (say, an NFS mount) and ensure that qbittorrent starts after that mount.

Without this dependency a system boot runs the risk of performing such a mount after qbittorrent starts, which invalidates the state of all torrents (and a manual force recheck being required, lest _all_ torrents are downloaded again).

Adding all of nixflix service dependencies is perhaps a little overzealous, but it is more uniform than adding another option.