### PR TITLE
prowlarr/indexers: add prowlarr.service ordering and forceSave=true

### DIFF
--- a/modules/prowlarr/indexers.nix
+++ b/modules/prowlarr/indexers.nix
@@ -81,10 +81,12 @@ in
       {
         description = "Configure Prowlarr indexers via API";
         after = [
+          "prowlarr.service"
           "prowlarr-config.service"
           "prowlarr-tags.service"
         ];
         requires = [
+          "prowlarr.service"
           "prowlarr-config.service"
           "prowlarr-tags.service"
         ];
@@ -235,7 +237,7 @@ in
                 RESPONSE_FILE=$(mktemp)
                 HTTP_CODE=$(
                   ${mkSecureCurl cfg.config.apiKey {
-                    url = "$BASE_URL/indexer/$INDEXER_ID";
+                    url = "$BASE_URL/indexer/$INDEXER_ID?forceSave=true";
                     method = "PUT";
                     headers = {
                       "Content-Type" = "application/json";
@@ -283,7 +285,7 @@ in
                 RESPONSE_FILE=$(mktemp)
                 HTTP_CODE=$(
                   ${mkSecureCurl cfg.config.apiKey {
-                    url = "$BASE_URL/indexer";
+                    url = "$BASE_URL/indexer?forceSave=true";
                     method = "POST";
                     headers = {
                       "Content-Type" = "application/json";


### PR DESCRIPTION
## Problem

`prowlarr-indexers.service` fails in two distinct ways during `nixos-rebuild switch` / `colmena apply`, blocking the activation:

### 1. Activation ordering race

The unit is only ordered `After=prowlarr-config.service prowlarr-tags.service`. Both of those units complete *before* Prowlarr's own `ExecStartPost` wait-for-api script finishes, so `prowlarr-indexers` can start while the API is still initialising and get `curl: (7) Failed to connect`. Adding `prowlarr.service` directly to `After`/`Requires` closes the gap — `prowlarr.service`'s `ExecStartPost` already waits for the API to answer.

### 2. Indexer-site validation failing deploys

Prowlarr validates each indexer against its live tracking site on every POST/PUT. If a site is temporarily unreachable (maintenance, DNS flap, geo-block…) Prowlarr returns HTTP 400 and the script exits 1, causing the deploy to fail. Users end up manually removing and re-adding indexers just to keep deploys green.

`?forceSave=true` on the Prowlarr API (supported since v1; see `ProviderControllerBase.cs`) skips the live test and saves the configuration unconditionally. Prowlarr's health system then marks failing indexers and retries them on its own schedule — exactly the right place to handle transient availability.

## Changes

- `modules/prowlarr/indexers.nix`: add `prowlarr.service` to `after`/`requires`
- `modules/prowlarr/indexers.nix`: append `?forceSave=true` to indexer POST and PUT URLs