### PR TITLE
prowlarr/indexer-proxies: add forceSave=true to create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `prowlarr-indexer-proxies` restart-looping (and blocking boot) when the proxy's test endpoint is unreachable, by adding `?forceSave=true` to its create/update requests (mirrors [#247](https://github.com/kiriwalawren/nixflix/pull/247) for indexers).
 - `_secret` pattern not trimming all terminating newlines in decrypted files.
 - qBittorrent potentially starting before `nixflix.serviceDependencies` and thus losing track of downloaded files, lest a recheck was manually forced.
 

--- a/modules/prowlarr/indexerProxies.nix
+++ b/modules/prowlarr/indexerProxies.nix
@@ -214,7 +214,7 @@ in
 
                 ${
                   mkSecureCurl cfg.config.apiKey {
-                    url = "$BASE_URL/indexerProxy/$INDEXER_ID";
+                    url = "$BASE_URL/indexerProxy/$INDEXER_ID?forceSave=true";
                     method = "PUT";
                     headers = {
                       "Content-Type" = "application/json";
@@ -243,7 +243,7 @@ in
 
                 ${
                   mkSecureCurl cfg.config.apiKey {
-                    url = "$BASE_URL/indexerProxy";
+                    url = "$BASE_URL/indexerProxy?forceSave=true";
                     method = "POST";
                     headers = {
                       "Content-Type" = "application/json";


### PR DESCRIPTION
## Problem

`prowlarr-indexer-proxies.service` validates the proxy against its live test endpoint (`prowlarr.servarr.com` via FlareSolverr) on every POST/PUT. When that endpoint is unreachable — geo-block, DNS flap, or FlareSolverr unable to fetch it — Prowlarr returns HTTP 400 and the unit exits non-zero. With `Restart=on-failure` (and each attempt taking longer than the start-limit window) it **restart-loops indefinitely**, and since the unit is `wantedBy=multi-user.target` it blocks the entire machine/container boot.

Observed on a setup whose egress can't reach `prowlarr.servarr.com`: the proxy test fails with `net::ERR_NAME_NOT_RESOLVED` after ~40s, the unit restarts every 30s forever, and the (nspawn) container never reaches `multi-user.target`.

## Fix

Append `?forceSave=true` to the indexer-proxy create (POST) and update (PUT) URLs. This is a `ProviderControllerBase` flag that skips the live test and saves the config unconditionally — **exactly what #247 did for the indexers unit**. Prowlarr's health system then marks/retries failing proxies on its own schedule, which is the right place for transient availability.

## Changes

- `modules/prowlarr/indexerProxies.nix`: `?forceSave=true` on the POST and PUT URLs.