### PR TITLE
prowlarr/indexers: tolerate per-indexer failures, exit non-zero if any failed

### DIFF
--- a/modules/prowlarr/indexers.nix
+++ b/modules/prowlarr/indexers.nix
@@ -153,6 +153,12 @@ in
             fi
           done
 
+          # Run each indexer in its own subshell and fold its exit status into RC, so a
+          # single failing indexer doesn't abort the rest of the batch; exit non-zero at
+          # the end if any failed, so Restart=on-failure can retry the stragglers.
+          RC=0
+          set +e
+
           ${concatMapStringsSep "\n" (
             indexerConfig:
             let
@@ -187,6 +193,8 @@ in
               };
             in
             ''
+              (
+              set -e
               echo "Processing indexer: ${indexerName}"
 
               apply_field_overrides() {
@@ -303,10 +311,14 @@ in
                 rm -f "$RESPONSE_FILE"
                 echo "Indexer ${indexerName} created"
               fi
+              )
+              [ $? -eq 0 ] || RC=1
             ''
           ) cfg.config.indexers}
+          set -e
 
           echo "Prowlarr indexers configuration complete"
+          exit "$RC"
         '';
       };
 }


### PR DESCRIPTION
One indexer whose site is transiently down (502 / timeout on its capabilities fetch) aborts the whole `set -e` batch, leaving every indexer after it unconfigured, with no retry.

Run each indexer in a standalone subshell that re-enables errexit, folding its status into `RC`; exit non-zero at the end if any failed. A bad indexer is now contained instead of taking down the rest, and the unit still signals failure so `Restart=on-failure` picks up the stragglers once their sites recover.

(`( … ) || RC=1` does not work here — a subshell on the left of `||` has its `set -e` suppressed, so failures pass silently.)