### PR TITLE
fix default Movies library typeOptions type ("Movies" -> "Movie")

### DIFF
--- a/modules/jellyfin/libaries/options.nix
+++ b/modules/jellyfin/libaries/options.nix
@@ -571,7 +571,7 @@ in
 
       typeOptions = [
         {
-          type = "Movies";
+          type = "Movie";
           imageFetchers = [
             "TheMovieDb"
             "The Open Movie Database"


### PR DESCRIPTION
Fixes #271

Jellyfin matches `TypeOptions[].Type` against the item **class name** — `ProviderManager` calls `libraryOptions.GetTypeOptions(item.GetType().Name)`, and the movie item class is `Movie` (singular). The default Movies library (created when Radarr is enabled) declared `type = "Movies"`, which never matches, so its metadata/image fetcher restrictions silently never applied. With other metadata plugins installed (e.g. AniDB, auto-installed when `sonarr-anime` is enabled), those plugins participated in movie refreshes and overwrote movie display names with fuzzy anime matches — see #271 for examples.

This brings the Movies default in line with the other defaults (`Series`/`Season`/`Episode`), the `typeOptions` docs example (`type = "Movie"`), and the VM test assertion (`MusicAlbum`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
