### PR TITLE
Package Byparr

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,52 +141,6 @@
               echo ""
             '';
           };
-
-          test =
-            let
-              libs = with pkgs; [
-                gtk3
-                glib
-                nss
-                cairo
-                pango
-                cups
-                dbus
-                libxcb
-                libX11
-                libXcursor
-                libXi
-                gcc.cc.lib
-                alsa-lib
-              ];
-
-              python = pkgs.python3.withPackages (
-                ps: with ps; [
-                  # dependencies
-                  fastapi
-                  invisible_playwright
-                  playwright
-                  playwright-captcha # package
-                  pydantic
-                  pydantic-settings
-
-                  # runtime dependencies
-                  uvicorn
-                ]
-              );
-            in
-            pkgs.mkShell {
-              packages = libs ++ [
-                pkgs.xvfb
-                python
-              ];
-
-              BYPARR_SRC = pkgs.byparr.src;
-
-              shellHook = ''
-                export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath libs}:$LD_LIBRARY_PATH"
-              '';
-            };
         }
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,52 @@
               echo ""
             '';
           };
+
+          test =
+            let
+              libs = with pkgs; [
+                gtk3
+                glib
+                nss
+                cairo
+                pango
+                cups
+                dbus
+                libxcb
+                libX11
+                libXcursor
+                libXi
+                gcc.cc.lib
+                alsa-lib
+              ];
+
+              python = pkgs.python3.withPackages (
+                ps: with ps; [
+                  # dependencies
+                  fastapi
+                  invisible_playwright
+                  playwright
+                  playwright-captcha # package
+                  pydantic
+                  pydantic-settings
+
+                  # runtime dependencies
+                  uvicorn
+                ]
+              );
+            in
+            pkgs.mkShell {
+              packages = libs ++ [
+                pkgs.xvfb
+                python
+              ];
+
+              BYPARR_SRC = pkgs.byparr.src;
+
+              shellHook = ''
+                export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath libs}:$LD_LIBRARY_PATH"
+              '';
+            };
         }
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
         (import ./docs { inherit pkgs inputs; })
         // {
           default = self.packages.${system}.docs;
-          inherit (pkgs) maintainerr;
+          inherit (pkgs) maintainerr byparr;
         }
       );
 

--- a/pkgs/byparr.nix
+++ b/pkgs/byparr.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  pkgs,
+  stdenv,
+  fetchFromGitHub,
+
+  makeWrapper,
+
+  python3,
+}:
+
+let
+  python = python3.withPackages (
+    ps: with ps; [
+      # dependencies
+      fastapi
+      invisible_playwright
+      playwright
+      playwright-captcha # package
+      pydantic
+      pydantic-settings
+
+      # runtime dependencies
+      uvicorn
+    ]
+  );
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "byparr";
+  version = "ecdd4c112a60c5fb22c781f142537e0b3399e568";
+
+  src = fetchFromGitHub {
+    owner = "ThePhaseless";
+    repo = "Byparr";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-eIbWqbUNOcS0WVgszXPVIbDx0hhRH1d1o+K0JXAEdwY=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/byparr-${finalAttrs.version}}
+    cp -r * $out/share/byparr-${finalAttrs.version}/.
+
+    makeWrapper ${python}/bin/python $out/bin/byparr \
+      --add-flags "$out/share/byparr-${finalAttrs.version}/main.py" \
+      --prefix LD_LIBRARY_PATH : ${
+        pkgs.lib.makeLibraryPath [
+          pkgs.gtk3
+          pkgs.glib
+          pkgs.nss
+          pkgs.cairo
+          pkgs.pango
+          pkgs.cups
+          pkgs.dbus
+          pkgs.libxcb
+          pkgs.libx11
+          pkgs.libxcursor
+          pkgs.libxi
+          pkgs.gcc.cc.lib
+          pkgs.alsa-lib
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Get your valid antibot cookies yourself! ";
+    homepage = "https://github.com/ThePhaseless/Byparr";
+    license = lib.licenses.gpl3;
+    mainProgram = "byparr";
+  };
+})

--- a/pkgs/byparr.nix
+++ b/pkgs/byparr.nix
@@ -7,7 +7,7 @@
   makeWrapper,
 
   python3,
-  xvfb
+  xvfb,
 }:
 
 let
@@ -28,12 +28,12 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "byparr";
-  version = "ecdd4c112a60c5fb22c781f142537e0b3399e568";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "ThePhaseless";
     repo = "Byparr";
-    rev = "${finalAttrs.version}";
+    rev = "ecdd4c112a60c5fb22c781f142537e0b3399e568";
     hash = "sha256-eIbWqbUNOcS0WVgszXPVIbDx0hhRH1d1o+K0JXAEdwY=";
   };
 

--- a/pkgs/byparr.nix
+++ b/pkgs/byparr.nix
@@ -7,6 +7,7 @@
   makeWrapper,
 
   python3,
+  xvfb
 }:
 
 let
@@ -44,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper ${python}/bin/python $out/bin/byparr \
       --add-flags "$out/share/byparr-${finalAttrs.version}/main.py" \
+      --prefix PATH : "${lib.makeBinPath [ xvfb ]}" \
       --prefix LD_LIBRARY_PATH : ${
         pkgs.lib.makeLibraryPath [
           pkgs.gtk3

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -29,4 +29,15 @@ let
       )
   );
 in
-dirPkgs // filePkgs
+dirPkgs
+// filePkgs
+// {
+  pythonPackagesExtensions = _prev.pythonPackagesExtensions ++ [
+    (pyFinal: _pyPrev: {
+      invisible_core = pyFinal.callPackage ./python/invisible_core.nix { };
+      invisible_playwright = pyFinal.callPackage ./python/invisible_playwright.nix { };
+      playwright-captcha = pyFinal.callPackage ./python/playwright-captcha.nix { };
+      twocaptcha = pyFinal.callPackage ./python/2captcha-python.nix { };
+    })
+  ];
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -37,7 +37,7 @@ dirPkgs
       invisible_core = pyFinal.callPackage ./python/invisible_core.nix { };
       invisible_playwright = pyFinal.callPackage ./python/invisible_playwright.nix { };
       playwright-captcha = pyFinal.callPackage ./python/playwright-captcha.nix { };
-      twocaptcha = pyFinal.callPackage ./python/2captcha-python.nix { };
+      twocaptcha_async = pyFinal.callPackage ./python/2captcha-python-async.nix { };
     })
   ];
 }

--- a/pkgs/python/2captcha-python-async.nix
+++ b/pkgs/python/2captcha-python-async.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
 
   # build-system
   setuptools,
@@ -14,15 +14,14 @@
 }:
 
 buildPythonPackage (finalAttrs: {
-  pname = "2captcha-python";
-  version = "2.0.9";
+  pname = "2captcha-python-async";
+  version = "1.5.1";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "2captcha";
-    repo = "2captcha-python";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-bfeWuCvtVIl5JED6nDVYOpmVNRAwPt2fj9gudLIWAOU=";
+  src = fetchPypi {
+    inherit (finalAttrs) version;
+    pname = "2captcha_python_async";
+    hash = "sha256-ydW3PdrCOovNwblrB19xZZRcDXmDb4Nw04AtnFirMjY=";
   };
 
   build-system = [
@@ -34,9 +33,6 @@ buildPythonPackage (finalAttrs: {
     httpx
     aiofiles
   ];
-
-  # Skip tests because they require network access.
-  doCheck = false;
 
   pythonImportsCheck = [ "twocaptcha" ];
 

--- a/pkgs/python/2captcha-python.nix
+++ b/pkgs/python/2captcha-python.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  requests,
+  httpx,
+  aiofiles,
+
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "2captcha-python";
+  version = "2.0.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "2captcha";
+    repo = "2captcha-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bfeWuCvtVIl5JED6nDVYOpmVNRAwPt2fj9gudLIWAOU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    requests
+    httpx
+    aiofiles
+  ];
+
+  # Skip tests because they require network access.
+  doCheck = false;
+
+  pythonImportsCheck = [ "twocaptcha" ];
+
+  meta = {
+    description = "Python 3 package for easy integration with the API of 2captcha captcha solving service to bypass recaptcha, сloudflare turnstile, funcaptcha, geetest and solve any other captchas. ";
+    mainProgram = "2captcha";
+    homepage = "https://github.com/2captcha/2captcha-python";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/python/invisible_core.nix
+++ b/pkgs/python/invisible_core.nix
@@ -16,8 +16,6 @@
   maxminddb,
   tzdata,
   tqdm,
-
-  firefox,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -34,13 +32,6 @@ buildPythonPackage (finalAttrs: {
     rev = "${finalAttrs.version}";
     hash = "sha256-BiISHZFI/JStDVFeYXwZkRtthcbiaIe6iuDKFTJNmHs=";
   };
-
-  postPatch = ''
-    substituteInPlace src/invisible_core/constants.py \
-      --replace-fail \
-        '"linux": "firefox",' \
-        '"linux": "${lib.getExe firefox}"',
-  '';
 
   build-system = [
     hatchling

--- a/pkgs/python/invisible_core.nix
+++ b/pkgs/python/invisible_core.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # nativeBuildInputs
+  gitMinimal,
+  writableTmpDirAsHomeHook,
+
+  # dependencies
+  platformdirs,
+  requests,
+  maxminddb,
+  tzdata,
+  tqdm,
+
+  firefox,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "invisible_core";
+
+  # no actual release yet
+  version = "352f90c13a9aaef276bdc4bf552d348cd7e15eea";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "feder-cr";
+    repo = "invisible_core";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-BiISHZFI/JStDVFeYXwZkRtthcbiaIe6iuDKFTJNmHs=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/invisible_core/constants.py \
+      --replace-fail \
+        '"linux": "firefox",' \
+        '"linux": "${lib.getExe firefox}"',
+  '';
+
+  build-system = [
+    hatchling
+  ];
+
+  nativeBuildInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
+
+  dependencies = [
+    platformdirs
+    requests
+    maxminddb
+    tzdata
+    tqdm
+  ];
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "invisible_core" ];
+
+  meta = {
+    description = "Anti-Detect Browser that passes every bot detection test. Drop-in Playwright replacement.";
+    mainProgram = "invisible_playwright";
+    homepage = "https://github.com/feder-cr/invisible_core";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/python/invisible_core.nix
+++ b/pkgs/python/invisible_core.nix
@@ -18,19 +18,17 @@
   tqdm,
 }:
 
-buildPythonPackage (finalAttrs: {
+buildPythonPackage (_finalAttrs: {
   pname = "invisible_core";
-
-  # no actual release yet
-  version = "352f90c13a9aaef276bdc4bf552d348cd7e15eea";
+  version = "0.1.0";
 
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "feder-cr";
     repo = "invisible_core";
-    rev = "${finalAttrs.version}";
-    hash = "sha256-BiISHZFI/JStDVFeYXwZkRtthcbiaIe6iuDKFTJNmHs=";
+    rev = "897977f2e21f2c31dd2ef406b54df1ecce25fda1";
+    hash = "sha256-dzsrJHVoomipvV0jMqQf3TGJgRid+jUCHT8S7VfsIOA=";
   };
 
   build-system = [

--- a/pkgs/python/invisible_playwright.nix
+++ b/pkgs/python/invisible_playwright.nix
@@ -14,17 +14,17 @@
   playwright,
 }:
 
-buildPythonPackage (finalAttrs: {
-  pname = "playwright";
+buildPythonPackage (_finalAttrs: {
+  pname = "invisible_playwright";
 
-  version = "firefox-13";
+  version = "0.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "feder-cr";
     repo = "invisible_playwright";
-    tag = "${finalAttrs.version}";
-    hash = "sha256-amCEaSZb++lDx3Pmvfmx0WEV7k1oOUy9Jr9HjRBm914=";
+    rev = "310bb215df207be3a329c80fcfecaed715fdf5f4";
+    hash = "sha256-Qq1Oxrtxl2VDwA9k2iSLue3bhxG+5VBh2q3dvHqDao0=";
   };
 
   build-system = [

--- a/pkgs/python/invisible_playwright.nix
+++ b/pkgs/python/invisible_playwright.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # nativeBuildInputs
+  gitMinimal,
+
+  # dependencies
+  invisible_core,
+  playwright,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "playwright";
+
+  version = "firefox-13";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "feder-cr";
+    repo = "invisible_playwright";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-amCEaSZb++lDx3Pmvfmx0WEV7k1oOUy9Jr9HjRBm914=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  nativeBuildInputs = [
+    gitMinimal
+  ];
+
+  pythonRelaxDeps = [
+    "invisible_core"
+    "playwright"
+  ];
+  dependencies = [
+    invisible_core
+    playwright
+  ];
+
+  # Skip tests because they require network access.
+  doCheck = false;
+
+  pythonImportsCheck = [ "invisible_playwright" ];
+
+  meta = {
+    description = "Anti-Detect Browser that passes every bot detection test. Drop-in Playwright replacement.";
+    mainProgram = "invisible_playwright";
+    homepage = "https://github.com/feder-cr/invisible_playwright";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/python/invisible_playwright.nix
+++ b/pkgs/python/invisible_playwright.nix
@@ -35,10 +35,6 @@ buildPythonPackage (_finalAttrs: {
     gitMinimal
   ];
 
-  pythonRelaxDeps = [
-    "invisible_core"
-    "playwright"
-  ];
   dependencies = [
     invisible_core
     playwright

--- a/pkgs/python/playwright-captcha.nix
+++ b/pkgs/python/playwright-captcha.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  twocaptcha,
+  playwright,
+
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "playwright-captcha";
+  version = "2bdd880b6dd2c27133dc971f425f83e04c6c3849";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "techinz";
+    repo = "playwright-captcha";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-XiJeh44CTUnTdEQgeAUiEmfjs4HZ8H+rG8Avll6K/tc=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    twocaptcha
+    playwright
+  ];
+
+  # Skip tests because they require network access.
+  doCheck = false;
+
+  # Author used their own fork, which has since been merged.
+  dontCheckRuntimeDeps = true;
+
+  pythonImportsCheck = [ "playwright_captcha" ];
+
+  meta = {
+    description = "Automating captcha solving for Playwright. Supports Cloudflare Turnstile & Interstitial, and reCAPTCHA V2 & V3 with Click-based or API (2captcha) solving. Designed for easy integration with Playwright, Patchright, and Camoufox. ";
+    homepage = "https://github.com/techinz/playwright-captcha";
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/python/playwright-captcha.nix
+++ b/pkgs/python/playwright-captcha.nix
@@ -7,21 +7,20 @@
   setuptools,
 
   # dependencies
-  twocaptcha,
+  twocaptcha_async,
   playwright,
-
 }:
 
-buildPythonPackage (finalAttrs: {
+buildPythonPackage (_finalAttrs: {
   pname = "playwright-captcha";
-  version = "2bdd880b6dd2c27133dc971f425f83e04c6c3849";
+  version = "0.1.5";
 
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "techinz";
     repo = "playwright-captcha";
-    rev = "${finalAttrs.version}";
+    rev = "2bdd880b6dd2c27133dc971f425f83e04c6c3849";
     hash = "sha256-XiJeh44CTUnTdEQgeAUiEmfjs4HZ8H+rG8Avll6K/tc=";
   };
 
@@ -30,7 +29,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
-    twocaptcha
+    twocaptcha_async
     playwright
   ];
 


### PR DESCRIPTION
Resolves #181

Hello, so I am no expert on nix. I had a hard time getting stuff working with the latest versions of the repos that stuff was fetched from, so I kind of just went to Bazarr and ensured the versions were the exact same as in the uv.lock. I mean, I it could be packaged by using uv but that doesn't seem to be the nix way. 

I haven't actually made a service out of it yet, but if you see anything that can be improved or be done more nix-y, do let me know.

I can confirm this works, I ran `nix run .#byparr` and I can test it through the standard fastapi docs page. I can fetch some random indexer page.

I am also not sure how / if this should be upstreamed to nixpkgs. Byparr seems to depend on a few really random packages...