### PR TITLE
fix *arr rootfolders oneshot racing app startup

### DIFF
--- a/modules/arr-common/rootFolders.nix
+++ b/modules/arr-common/rootFolders.nix
@@ -12,6 +12,7 @@ let
     usesMediaDirs
     capitalizedName
     mkSecureCurl
+    mkWaitForApiScript
     ;
 in
 {
@@ -50,6 +51,7 @@ in
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
+            ExecStartPre = mkWaitForApiScript serviceName cfg.config;
           };
 
           script = ''

--- a/tests/vm-tests/full-stack.nix
+++ b/tests/vm-tests/full-stack.nix
@@ -275,6 +275,22 @@ pkgsUnfree.testers.runNixOSTest {
                 f"Category {cat['name']} directory mismatch: expected {cat['name']}, got {cat['dir']}"
 
     print("SABnzbd categories configuration verified successfully!")
+
+    for service, port, api_version, api_key, folder in [
+        ("sonarr", 8989, "v3", "sonarr222222222222222222222222222", "/media/tv"),
+        ("sonarr-anime", 8990, "v3", "sonarr222222222222222222222222222", "/media/tv"),
+        ("radarr", 7878, "v3", "radarr333333333333333333333333333", "/media/movies"),
+        ("lidarr", 8686, "v1", "lidarr444444444444444444444444444", "/media/music"),
+    ]:
+        machine.succeed(f"systemctl restart --no-block {service}.service; systemctl restart {service}-rootfolders.service")
+        machine.wait_for_unit(f"{service}-rootfolders.service", timeout=180)
+        folders = machine.succeed(
+            f"curl -s -H 'X-Api-Key: {api_key}' "
+            f"http://127.0.0.1:{port}/api/{api_version}/rootfolder"
+        )
+        assert folder in folders, f"{service} root folder missing after concurrent restart"
+        print(f"{service} root folders reconciled after a restart racing app startup!")
+
     print("All services are running successfully!")
   '';
 }


### PR DESCRIPTION

Hey, ran into a problem where I changed my mounts and the service came up before the mounts did. Noticed ´mkWaitForApiScript´ already exists, just isn't used for the root folders.


Disclaimer: change was assisted by LLM. Full report/testing below

## Report

`<serviceName>-rootfolders` is the only API reconciler that adds `nixflix.serviceDependencies` to its `after`/`requires`, so a remount of one of those mounts propagates a restart to it while `<serviceName>.service` is still coming back up. `<serviceName>-config.service` is `RemainAfterExit=true` and doesn't require those deps, so the `wait-for-api` it owns doesn't re-run — the reconciler's first `curl -Sf $BASE_URL/rootfolder` hits a closed port and `set -e` kills the oneshot with exit 7.
   >
   > Hit on an NFS-backed host: `sonarr-rootfolders` started at 17:19:00 while `sonarr.service` only reached active at 17:19:02, with `sonarr-config.service` untouched since Jul 25. Fix reuses the `ExecStartPre` already on `<serviceName>-config.service`. Added VM test step fails on `main` with `status=7/NOTRUNNING` and passes with the fix.
   
## Testing

Local `nix build .#checks.x86_64-linux.<check>` on x86_64-linux, flake.lock unchanged:
`full-stack`, `sonarr-basic`, `radarr-basic`, `lidarr-basic`, `sonarr-anime-basic`,
`unit-tests`, `formatting` — all pass.

With `modules/arr-common/rootFolders.nix` reverted to main and the new full-stack step
kept, the test fails with the reported signature:

    [48.857626] sonarr-rootfolders.service: Main process exited, code=exited, status=7/NOTRUNNING
    !!! RequestedAssertionFailed: command `systemctl restart --no-block sonarr.service;
        systemctl restart sonarr-rootfolders.service` failed (exit code 1)

With the fix, all four *arr services reconcile after a restart racing app startup:

    sonarr root folders reconciled after a restart racing app startup!
    sonarr-anime root folders reconciled after a restart racing app startup!
    radarr root folders reconciled after a restart racing app startup!
    lidarr root folders reconciled after a restart racing app startup!

Not run locally: jellyfin/prowlarr/seerr/maintainerr/qbittorrent/sabnzbd/recyclarr basics,
the caddy/nginx/postgresql/vpn integration tests, docs-build — none instantiate
rootFolders.nix.