### PR TITLE
docs: some fixes on options reference doc

### DIFF
--- a/modules/downloadarr/options.nix
+++ b/modules/downloadarr/options.nix
@@ -37,7 +37,7 @@ let
         prowlarr = mkOption {
           type = types.str;
           default = "prowlarr";
-          description = "The categories to use for the Lidarr instance";
+          description = "The categories to use for the Prowlarr instance";
         };
       };
     };
@@ -215,7 +215,7 @@ let
     implementationName = "rTorrent";
 
     port = {
-      description = "Port of the download client. This competes with SABnzbd.";
+      description = "Port of the download client. Note: SABnzbd also defaults to port 8080, so set distinct ports when both are enabled.";
     };
 
     urlBase = {
@@ -318,7 +318,7 @@ in
         transmission = mkOption {
           type = transmissionType;
           default = { };
-          description = "Transmission Deluge download client definition for Starr services.";
+          description = "Transmission download client definition for Starr services.";
         };
 
         extraClients = mkOption {

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -254,7 +254,7 @@ in
             Setting this to any path, where the subpath is not owned by root, will fail! For example:
 
             ```nix
-            mediaDir = /home/user/data
+            downloadsDir = /home/user/data
             ```
 
             Is not supported, because `/home/user` is owned by `user`.
@@ -277,7 +277,7 @@ in
             Setting this to any path, where the subpath is not owned by root, will fail! For example:
 
             ```nix
-            mediaDir = /home/user/data
+            stateDir = /home/user/data
             ```
 
             Is not supported, because `/home/user` is owned by `user`.


### PR DESCRIPTION
I found some more small typos in the way some options are documented