### PR TITLE
fix: _secret refs nested inside lists being silently dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fix \*arr rootfolders oneshot racing app startup ([#286](https://github.com/kiriwalawren/nixflix/pull/286))
 - fix \*arr `config.hostConfig` auth/port/urlBase values being ignored in favor of hardcoded `settings` env vars ([#289](https://github.com/kiriwalawren/nixflix/pull/289))
 - fix Jellyfin crash-looping on boot when a stale `TranscodingTempPath` in `encoding.xml` points at an inaccessible path after `cacheDir`/`encoding.transcodingTempPath` changes ([#291](https://github.com/kiriwalawren/nixflix/pull/291))
+- fix `_secret` refs nested inside lists being silently dropped and POSTed as `null`, e.g. the Jellyfin Webhook plugin's `GenericOptions` ([#302](https://github.com/kiriwalawren/nixflix/pull/302))
 
 ## [3.0.0] - 2026-07-12
 

--- a/lib/secrets/default.nix
+++ b/lib/secrets/default.nix
@@ -95,7 +95,7 @@ rec {
       value;
 
   # Collect every ._secret ref in a nested structure as a list of
-  # { path = ["key" "sub" ...]; file = "/runtime/path"; } records.
+  # { path = ["key" 0 "sub" ...]; file = "/runtime/path"; } records.
   collectSecretRefsRec =
     path: value:
     if isSecretRef value then
@@ -107,6 +107,8 @@ rec {
       ]
     else if builtins.isAttrs value && !(value ? __unfix__) then
       lib.concatLists (lib.mapAttrsToList (k: v: collectSecretRefsRec (path ++ [ k ]) v) value)
+    else if builtins.isList value then
+      lib.concatLists (lib.imap0 (i: v: collectSecretRefsRec (path ++ [ i ]) v) value)
     else
       [ ];
 
@@ -122,7 +124,11 @@ rec {
       assignments = map (
         ref:
         let
-          jqPath = "." + lib.concatMapStringsSep "" (k: ''["${k}"]'') ref.path;
+          jqPath =
+            "."
+            + lib.concatMapStringsSep "" (
+              k: if builtins.isInt k then "[${toString k}]" else ''["${k}"]''
+            ) ref.path;
         in
         "${jqPath} = ($" + ref.varName + ''Content | sub("\n+$"; ""))''
       ) indexedRefs;

--- a/tests/unit-tests/default.nix
+++ b/tests/unit-tests/default.nix
@@ -6,6 +6,7 @@
 let
   inherit (pkgs) lib;
   jellyfinPlugins = import ../../lib/jellyfin-plugins.nix { inherit lib; };
+  secrets = import ../../lib/secrets { inherit lib; };
   manifestHash =
     file:
     builtins.convertHash {
@@ -903,4 +904,38 @@ in
       radarrCfg = config.config.nixflix.radarr;
     in
     assertTest "settings-auth-overrides-hostconfig" (radarrCfg.settings.auth.method == "External");
+
+  nested-secret-in-list-jq-filter =
+    let
+      rawConfig = {
+        Entries = [
+          {
+            Name = "first";
+            Value._secret = secretFile;
+          }
+        ];
+      };
+      secretFile = pkgs.writeText "entry-value" "s3cr3t-value\n";
+      plainFile = pkgs.writeText "plain.json" (builtins.toJSON (secrets.stripSecretRefs rawConfig));
+      jqSecrets = secrets.mkNestedJqSecretArgs rawConfig;
+    in
+    pkgs.runCommand "unit-test-nested-secret-in-list-jq-filter"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+      }
+      ''
+        merged=$(
+          echo '{"Entries":[]}' \
+            | jq \
+                ${jqSecrets.flagsString} \
+                --argjson plain "$(cat ${plainFile})" \
+                '. * $plain | ${lib.concatStringsSep " | " jqSecrets.assignments}'
+        )
+
+        value=$(echo "$merged" | jq -r '.Entries[0].Value')
+        if [ "$value" != "s3cr3t-value" ]; then
+          echo "FAIL: expected substituted value, got '$value'" && exit 1
+        fi
+        echo 'PASS: nested-secret-in-list-jq-filter' > $out
+      '';
 }


### PR DESCRIPTION
# Summary

`_secret` refs nested inside a list are silently dropped and POSTed as null. This makes it impossible to declaratively configure any Jellyfin plugin whose configuration payload is a list, for example the Webhook plugin's GenericOptions.

What I was trying to do

I wanted to point Jellyfin's Webhook plugin at a self-hosted [Yamtrack](https://github.com/FuzzyGrim/Yamtrack) instance so playback events scrobble automatically. The webhook URL embeds a per-user API token.

The natural nixflix expression:

```nix
nixflix.jellyfin.plugins.Webhook = {
  package = nixflix.lib.jellyfinPlugins.fromRepo {
    version = "21.0.0.0";
    hash = "...";
  };

  config.GenericOptions = [
    {
      WebhookName = "Yamtrack";
      WebhookUri._secret = config.sops.templates."yamtrack-webhook-uri".path;
      NotificationTypes = [ 3 5 ];  # PlaybackStart, PlaybackStop
      EnableMovies = true;
      EnableEpisodes = true;
      Template = "<base64 handlebars template>";
    }
  ];
};
```

## What broke, and why

The plugin is configured, but `WebhookUri` arrives as null. Jellyfin then posts every event to an invalid URL and every scrobble 401s. There is no error at eval time, at activation, or in the unit log.

The cause is a disagreement between two functions in `lib/secrets/default.nix`. `stripSecretRefs` recurses into lists:

```nix
stripSecretRefs =
  value:
  if isSecretRef value then null
  else if builtins.isAttrs value && !(value ? __unfix__) then
    lib.mapAttrs (_: stripSecretRefs) value
  else if builtins.isList value then          # <-- handles lists
    map stripSecretRefs value
  else value;
```

`collectSecretRefsRec`, directly below it, does not:

```nix
collectSecretRefsRec =
  path: value:
  if isSecretRef value then [ { inherit path; file = toString value._secret; } ]
  else if builtins.isAttrs value && !(value ? __unfix__) then
    lib.concatLists (lib.mapAttrsToList (k: v: collectSecretRefsRec (path ++ [ k ]) v) value)
  else [ ];
```

```
  <WebhookName>Yamtrack</WebhookName>
  <WebhookUri />          <!-- null -->
  ...
</GenericOption>
```

## Current workaround

I bypass `nixflix.jellyfin.plugins.<name>.config` entirely and drive the plugin API from my own oneshot:

```nix
yamtrack-jellyfin-webhook = {
  description = "Configure the Yamtrack destination in the Jellyfin Webhook plugin";
  after = [ "jellyfin-plugins.service" "yamtrack-admin.service" ];
  requires = [ "jellyfin-plugins.service" "yamtrack-admin.service" ];
  wantedBy = [ "multi-user.target" ];

  serviceConfig = {
    Type = "oneshot";
    RemainAfterExit = true;
    ExecStart = pkgs.writeShellScript "yamtrack-jellyfin-webhook" ''
      set -euo pipefail

      curl=(
        ${lib.getExe pkgs.curl} -sSf
        --variable "auth@${jellyfinAuthToken}"
        --expand-header "Authorization: {{auth:trim}}"
      )
      api="${jellyfinUrl}/Plugins"

      id=$("''${curl[@]}" "$api" \
        | ${lib.getExe pkgs.jq} -r '.[] | select(.Name == "Webhook") | .Id')
      : "''${id:?Webhook plugin not installed}"

      "''${curl[@]}" "$api/$id/Configuration" \
        | ${lib.getExe pkgs.jq} \
            --argjson dest ${lib.escapeShellArg webhookDestination} \
            --rawfile token ${config.sops.secrets.${webhookToken}.path} \
            --from-file ${mergeWebhookFilter} \
        | "''${curl[@]}" -X POST -H "Content-Type: application/json" \
            --data-binary @- "$api/$id/Configuration"
    '';
  };
};
```

with the merge filter:

```
jq
.GenericOptions = [ $dest + {
    Template: ($dest.Template | @base64),
    WebhookUri: "http://<fqdn>/webhook/jellyfin/\($token | rtrimstr("\n"))",
  } ] + [ .GenericOptions[]? | select(.WebhookName != $dest.WebhookName) ]
```

This works, but it duplicates machinery nixflix already has and has to be maintained separately.

# The fix

Two changes in `lib/secrets/default.nix`, which must go together:

1. `collectSecretRefsRec` gains a `builtins.isList` branch using `lib.imap0`, mirroring what `stripSecretRefs` already does. Path elements are now ints for list indices.
2. `mkNestedJqSecretArgs` renders an int path element as [0] rather than ["0"].

# Test

Added `nested-secret-in-list-jq-filter`. It builds the flags and assignments for a config with a `_secret` inside a list element, then runs real `jq` through the same `. * $plain | ...` shape `pluginsService.nix `uses, asserting the secret value lands in the output.

# Important note 

I think that this behavior is expected but wanted to ensure it's fully right: `pluginsService.nix` merges with `. * $plain`, and jq's * merges objects recursively but replaces arrays wholesale. So once a plugin config declares a list, nixflix owns that entire array and any entry added through the Jellyfin UI is dropped on the next rebuild.