### PR TITLE
fix: add support for serviceDependencies for navidrome

### DIFF
--- a/modules/navidrome/default.nix
+++ b/modules/navidrome/default.nix
@@ -245,6 +245,11 @@ in
         ];
 
         systemd = {
+          services.navidrome = {
+            after = config.nixflix.serviceDependencies;
+            requires = config.nixflix.serviceDependencies;
+          };
+
           tmpfiles.settings.navidromeDirs = {
             "${cfg.settings.DataFolder}"."d" = lib.mkForce {
               mode = "755";


### PR DESCRIPTION
Hey,

I just tested the new Navidrome support and it works well thanks a lot!

I noticed navidrome wasn't respecting the global `serviceDependencies` directive, I don't know if it's a bug or if it's intentional (as navidrome is very different from the other services). I personnally use `serviceDependencies` for a nfs mount that's shared across all the services as that's where I stored all my data.