### PR TITLE
docs: document navidrome setup in basic setup

### DIFF
--- a/docs/examples/basic-setup.md
+++ b/docs/examples/basic-setup.md
@@ -169,8 +169,8 @@ This example shows a working media server configuration based on a real producti
     navidrome = {
       enable = true;
       users = {
-        admin = {
-          userName = "admin";
+        "Alice" = { # name displayed in the UI
+          userName = "alice"; # username used to login
           isAdmin = true;
           password._secret = config.sops.secrets."navidrome/password".path;
         };
@@ -288,6 +288,7 @@ Replace these with your own values:
 - **Accessible from**: Update `192.168.1.0/24` to your local network subnet
 - **Theme**: Change `"overseer"` to another theme.park theme
 - **Jellyfin user**: Change `alice` to your username
+- **Navidrome user**: Change `alice` to your username
 
 ## Next Steps
 

--- a/docs/examples/basic-setup.md
+++ b/docs/examples/basic-setup.md
@@ -33,6 +33,7 @@ This example shows a working media server configuration based on a real producti
     "usenet/eweka/password" = {};
     "usenet/newsgroupdirect/username" = {};
     "usenet/newsgroupdirect/password" = {};
+    "navidrome/password" = {};
   };
 
   nixflix = {
@@ -165,6 +166,20 @@ This example shows a working media server configuration based on a real producti
       apiKey._secret = config.sops.secrets."seerr/api_key".path;
     };
 
+    navidrome = {
+      enable = true;
+      users = {
+        admin = {
+          userName = "admin";
+          isAdmin = true;
+          password._secret = config.sops.secrets."navidrome/password".path;
+        };
+      };
+      settings = {
+        MusicFolder = "/data/media/music";
+      };
+    };
+
     vpn = {
       enable = true;
       wgConfFile = config.sops.secrets."wireguard/conf".path;
@@ -182,6 +197,7 @@ This example shows a working media server configuration based on a real producti
 - **Sonarr Anime** - Anime shows
 - **Radarr** - Movies
 - **Lidarr** - Music
+- **Navidrome** - Music Server
 - **Prowlarr** - Indexer management with 3 pre-configured indexers
 - **SABnzbd** - Usenet downloads with 2 providers
 - **Jellyfin** - Media streaming with automatic library configuration
@@ -238,6 +254,7 @@ This example shows a working media server configuration based on a real producti
 └── .state/
     ├── jellyfin/
     ├── lidarr/
+    ├── navidrome/
     ├── postgres/
     ├── prowlarr/
     ├── radarr/
@@ -259,6 +276,7 @@ This example shows a working media server configuration based on a real producti
 | qBittorrent | `http://qbittorrent.nixflix` | `http://localhost:8282` | `admin` |
 | Jellyfin | `http://jellyfin.nixflix` | `http://localhost:8096` | `admin` |
 | Seerr | `http://seerr.nixflix` | `http://localhost:5055` | `seerr` (local), `admin` (Jellyfin auth) |
+| Navidrome | `http://navidrome.nixflix` | `http://localhost:4533` | `admin` |
 
 ## Customization
 

--- a/docs/examples/basic-setup.md
+++ b/docs/examples/basic-setup.md
@@ -209,7 +209,7 @@ This example shows a working media server configuration based on a real producti
 
 - **PostgreSQL** - Database backend for better performance
 - **Nginx** (or **Caddy**) - Reverse proxy for all services
-- **theme.park** - UI theming (set to "plex" theme)
+- **theme.park** - UI theming (set to "overseer" theme)
 
 ### Automatic Integration
 
@@ -286,7 +286,7 @@ Replace these with your own values:
 - **Usenet providers**: Update server details for your providers
 - **VPN**: Replace `wireguard/conf` with the sops path to your wg-quick `.conf` file
 - **Accessible from**: Update `192.168.1.0/24` to your local network subnet
-- **Theme**: Change `"plex"` to another theme.park theme
+- **Theme**: Change `"overseer"` to another theme.park theme
 - **Jellyfin user**: Change `alice` to your username
 
 ## Next Steps

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -157,6 +157,15 @@ Here's a minimal configuration to get started:
         password = {_secret = config.sops.secrets."jellyfin/admin_password".path;};
       };
     };
+
+    navidrome = {
+      enable = true;
+      users.admin = {
+        userName = "admin";
+        isAdmin = true;
+        password = {_secret = config.sops.secrets."navidrome/admin_password".path;};
+      };
+    };
   };
 }
 ```

--- a/modules/navidrome/default.nix
+++ b/modules/navidrome/default.nix
@@ -52,7 +52,7 @@ in
                   type = lib.types.str;
                   example = "username";
                   default = null;
-                  description = "Username for the user.";
+                  description = "Username for the user (used to login).";
                 };
 
                 email = lib.mkOption {


### PR DESCRIPTION
Hey not sure if you were working on it but I took the liberty to document the new Navidrome integration in the getting started and the basic setup guides :+1: 

From my testing the `userName` is mandatory for Navidrome so I added it as well.

I also fixed the theme examples to `overseer` as it was the one used in the code sample (i looked at the code and it seems this option is not fully developed yet so impact is low).