### PR TITLE
fix a few unexpected errors with `*arr` modules and seerr's sonarr integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(seer/sonarr): requirement on radarr and require `seerr-libraries` like seer/radarr ([#311](https://github.com/kiriwalawren/nixflix/pull/311))
 - fix navidrome dependency on `serviceDependencies` ([#306](https://github.com/kiriwalawren/nixflix/pull/306))
 - fix seerr sonarr activeDirectory default resolving host config ([#283](https://github.com/kiriwalawren/nixflix/pull/283))
 - fix \*arr rootfolders oneshot racing app startup ([#286](https://github.com/kiriwalawren/nixflix/pull/286))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(arr-common): silent failure of arr-config services not generating if `username` & `password` were both `null` ([#311](https://github.com/kiriwalawren/nixflix/pull/311))
 - fix(seer/sonarr): requirement on radarr and require `seerr-libraries` like seer/radarr ([#311](https://github.com/kiriwalawren/nixflix/pull/311))
 - fix navidrome dependency on `serviceDependencies` ([#306](https://github.com/kiriwalawren/nixflix/pull/306))
 - fix seerr sonarr activeDirectory default resolving host config ([#283](https://github.com/kiriwalawren/nixflix/pull/283))

--- a/modules/arr-common/hostConfig.nix
+++ b/modules/arr-common/hostConfig.nix
@@ -278,7 +278,6 @@ in
         config.nixflix.enable
         && cfg.enable
         && cfg.config.apiKey != null
-        && cfg.config.hostConfig.password != null
       )
       {
         systemd.services."${serviceName}-config" =

--- a/modules/arr-common/hostConfig.nix
+++ b/modules/arr-common/hostConfig.nix
@@ -273,144 +273,137 @@ in
       ];
     })
 
-    (mkIf
-      (
-        config.nixflix.enable
-        && cfg.enable
-        && cfg.config.apiKey != null
-      )
-      {
-        systemd.services."${serviceName}-config" =
-          let
-            hc = cfg.config.hostConfig;
-            jqSecrets = secrets.mkJqSecretArgs {
-              inherit (cfg.config) apiKey;
-              inherit (hc)
-                username
-                password
-                sslCertPassword
-                proxyUsername
-                proxyPassword
-                ;
-            };
-          in
-          {
-            description = "Configure ${serviceName} via API";
-            after = [ "${serviceName}.service" ];
-            # DO NOT ADD `requires` here — <service>-config restarts
-            # the service and would enter failed state as a result
-            wantedBy = [ "multi-user.target" ];
-
-            serviceConfig = {
-              Type = "oneshot";
-              RemainAfterExit = true;
-              ExecStartPre = mkWaitForApiScript serviceName cfg.config;
-              ExecStartPost = mkWaitForApiScript serviceName cfg.config;
-            };
-
-            script = ''
-              set -eu
-
-              BASE_URL="http://${hc.bindAddress}:${builtins.toString hc.port}${hc.urlBase}/api/${cfg.config.apiVersion}"
-
-              echo "Fetching current host configuration..."
-              HOST_CONFIG=$(${
-                mkSecureCurl cfg.config.apiKey {
-                  url = "$BASE_URL/config/host";
-                  extraArgs = "-f";
-                }
-              } 2>/dev/null)
-
-              if [ -z "$HOST_CONFIG" ]; then
-                echo "Failed to fetch host configuration"
-                exit 1
-              fi
-
-              CONFIG_ID=$(echo "$HOST_CONFIG" | ${pkgs.jq}/bin/jq -r '.id')
-
-              echo "Building configuration..."
-              NEW_CONFIG=$(${pkgs.jq}/bin/jq -n \
-                ${jqSecrets.flagsString} \
-                --argjson id "$CONFIG_ID" \
-                --arg bindAddress ${escapeShellArg hc.bindAddress} \
-                --arg authenticationMethod ${escapeShellArg hc.authenticationMethod} \
-                --arg authenticationRequired ${escapeShellArg hc.authenticationRequired} \
-                --arg logLevel ${escapeShellArg hc.logLevel} \
-                --arg consoleLogLevel ${escapeShellArg hc.consoleLogLevel} \
-                --arg branch ${escapeShellArg hc.branch} \
-                --arg sslCertPath ${escapeShellArg hc.sslCertPath} \
-                --arg urlBase ${escapeShellArg hc.urlBase} \
-                --arg instanceName ${escapeShellArg hc.instanceName} \
-                --arg applicationUrl ${escapeShellArg hc.applicationUrl} \
-                --arg updateMechanism ${escapeShellArg hc.updateMechanism} \
-                --arg updateScriptPath ${escapeShellArg hc.updateScriptPath} \
-                --arg proxyType ${escapeShellArg hc.proxyType} \
-                --arg proxyHostname ${escapeShellArg hc.proxyHostname} \
-                --arg proxyBypassFilter ${escapeShellArg hc.proxyBypassFilter} \
-                --arg certificateValidation ${escapeShellArg hc.certificateValidation} \
-                --arg backupFolder ${escapeShellArg hc.backupFolder} \
-                '{
-                  id: $id,
-                  bindAddress: $bindAddress,
-                  port: ${builtins.toString hc.port},
-                  sslPort: ${builtins.toString hc.sslPort},
-                  enableSsl: ${boolToString hc.enableSsl},
-                  launchBrowser: ${boolToString hc.launchBrowser},
-                  authenticationMethod: $authenticationMethod,
-                  authenticationRequired: $authenticationRequired,
-                  analyticsEnabled: ${boolToString hc.analyticsEnabled},
-                  username: ${jqSecrets.refs.username},
-                  password: ${jqSecrets.refs.password},
-                  passwordConfirmation: ${jqSecrets.refs.password},
-                  logLevel: $logLevel,
-                  logSizeLimit: ${builtins.toString hc.logSizeLimit},
-                  consoleLogLevel: $consoleLogLevel,
-                  branch: $branch,
-                  apiKey: ${jqSecrets.refs.apiKey},
-                  sslCertPath: $sslCertPath,
-                  sslCertPassword: ${jqSecrets.refs.sslCertPassword},
-                  urlBase: $urlBase,
-                  instanceName: $instanceName,
-                  applicationUrl: $applicationUrl,
-                  updateAutomatically: ${boolToString hc.updateAutomatically},
-                  updateMechanism: $updateMechanism,
-                  updateScriptPath: $updateScriptPath,
-                  proxyEnabled: ${boolToString hc.proxyEnabled},
-                  proxyType: $proxyType,
-                  proxyHostname: $proxyHostname,
-                  proxyPort: ${builtins.toString hc.proxyPort},
-                  proxyUsername: ${jqSecrets.refs.proxyUsername},
-                  proxyPassword: ${jqSecrets.refs.proxyPassword},
-                  proxyBypassFilter: $proxyBypassFilter,
-                  proxyBypassLocalAddresses: ${boolToString hc.proxyBypassLocalAddresses},
-                  certificateValidation: $certificateValidation,
-                  backupFolder: $backupFolder,
-                  backupInterval: ${builtins.toString hc.backupInterval},
-                  backupRetention: ${builtins.toString hc.backupRetention},
-                  trustCgnatIpAddresses: ${boolToString hc.trustCgnatIpAddresses}
-                }')
-
-              echo "Updating ${capitalizedName} configuration via API..."
-              ${
-                mkSecureCurl cfg.config.apiKey {
-                  url = "$BASE_URL/config/host/$CONFIG_ID";
-                  method = "PUT";
-                  headers = {
-                    "Content-Type" = "application/json";
-                  };
-                  data = "$NEW_CONFIG";
-                  extraArgs = "-f";
-                }
-              } > /dev/null
-
-              echo "Configuration updated successfully"
-
-              echo "Restarting ${serviceName} service..."
-              systemctl restart ${serviceName}.service
-              echo "${capitalizedName} service restarted"
-            '';
+    (mkIf (config.nixflix.enable && cfg.enable && cfg.config.apiKey != null) {
+      systemd.services."${serviceName}-config" =
+        let
+          hc = cfg.config.hostConfig;
+          jqSecrets = secrets.mkJqSecretArgs {
+            inherit (cfg.config) apiKey;
+            inherit (hc)
+              username
+              password
+              sslCertPassword
+              proxyUsername
+              proxyPassword
+              ;
           };
-      }
-    )
+        in
+        {
+          description = "Configure ${serviceName} via API";
+          after = [ "${serviceName}.service" ];
+          # DO NOT ADD `requires` here — <service>-config restarts
+          # the service and would enter failed state as a result
+          wantedBy = [ "multi-user.target" ];
+
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStartPre = mkWaitForApiScript serviceName cfg.config;
+            ExecStartPost = mkWaitForApiScript serviceName cfg.config;
+          };
+
+          script = ''
+            set -eu
+
+            BASE_URL="http://${hc.bindAddress}:${builtins.toString hc.port}${hc.urlBase}/api/${cfg.config.apiVersion}"
+
+            echo "Fetching current host configuration..."
+            HOST_CONFIG=$(${
+              mkSecureCurl cfg.config.apiKey {
+                url = "$BASE_URL/config/host";
+                extraArgs = "-f";
+              }
+            } 2>/dev/null)
+
+            if [ -z "$HOST_CONFIG" ]; then
+              echo "Failed to fetch host configuration"
+              exit 1
+            fi
+
+            CONFIG_ID=$(echo "$HOST_CONFIG" | ${pkgs.jq}/bin/jq -r '.id')
+
+            echo "Building configuration..."
+            NEW_CONFIG=$(${pkgs.jq}/bin/jq -n \
+              ${jqSecrets.flagsString} \
+              --argjson id "$CONFIG_ID" \
+              --arg bindAddress ${escapeShellArg hc.bindAddress} \
+              --arg authenticationMethod ${escapeShellArg hc.authenticationMethod} \
+              --arg authenticationRequired ${escapeShellArg hc.authenticationRequired} \
+              --arg logLevel ${escapeShellArg hc.logLevel} \
+              --arg consoleLogLevel ${escapeShellArg hc.consoleLogLevel} \
+              --arg branch ${escapeShellArg hc.branch} \
+              --arg sslCertPath ${escapeShellArg hc.sslCertPath} \
+              --arg urlBase ${escapeShellArg hc.urlBase} \
+              --arg instanceName ${escapeShellArg hc.instanceName} \
+              --arg applicationUrl ${escapeShellArg hc.applicationUrl} \
+              --arg updateMechanism ${escapeShellArg hc.updateMechanism} \
+              --arg updateScriptPath ${escapeShellArg hc.updateScriptPath} \
+              --arg proxyType ${escapeShellArg hc.proxyType} \
+              --arg proxyHostname ${escapeShellArg hc.proxyHostname} \
+              --arg proxyBypassFilter ${escapeShellArg hc.proxyBypassFilter} \
+              --arg certificateValidation ${escapeShellArg hc.certificateValidation} \
+              --arg backupFolder ${escapeShellArg hc.backupFolder} \
+              '{
+                id: $id,
+                bindAddress: $bindAddress,
+                port: ${builtins.toString hc.port},
+                sslPort: ${builtins.toString hc.sslPort},
+                enableSsl: ${boolToString hc.enableSsl},
+                launchBrowser: ${boolToString hc.launchBrowser},
+                authenticationMethod: $authenticationMethod,
+                authenticationRequired: $authenticationRequired,
+                analyticsEnabled: ${boolToString hc.analyticsEnabled},
+                username: ${jqSecrets.refs.username},
+                password: ${jqSecrets.refs.password},
+                passwordConfirmation: ${jqSecrets.refs.password},
+                logLevel: $logLevel,
+                logSizeLimit: ${builtins.toString hc.logSizeLimit},
+                consoleLogLevel: $consoleLogLevel,
+                branch: $branch,
+                apiKey: ${jqSecrets.refs.apiKey},
+                sslCertPath: $sslCertPath,
+                sslCertPassword: ${jqSecrets.refs.sslCertPassword},
+                urlBase: $urlBase,
+                instanceName: $instanceName,
+                applicationUrl: $applicationUrl,
+                updateAutomatically: ${boolToString hc.updateAutomatically},
+                updateMechanism: $updateMechanism,
+                updateScriptPath: $updateScriptPath,
+                proxyEnabled: ${boolToString hc.proxyEnabled},
+                proxyType: $proxyType,
+                proxyHostname: $proxyHostname,
+                proxyPort: ${builtins.toString hc.proxyPort},
+                proxyUsername: ${jqSecrets.refs.proxyUsername},
+                proxyPassword: ${jqSecrets.refs.proxyPassword},
+                proxyBypassFilter: $proxyBypassFilter,
+                proxyBypassLocalAddresses: ${boolToString hc.proxyBypassLocalAddresses},
+                certificateValidation: $certificateValidation,
+                backupFolder: $backupFolder,
+                backupInterval: ${builtins.toString hc.backupInterval},
+                backupRetention: ${builtins.toString hc.backupRetention},
+                trustCgnatIpAddresses: ${boolToString hc.trustCgnatIpAddresses}
+              }')
+
+            echo "Updating ${capitalizedName} configuration via API..."
+            ${
+              mkSecureCurl cfg.config.apiKey {
+                url = "$BASE_URL/config/host/$CONFIG_ID";
+                method = "PUT";
+                headers = {
+                  "Content-Type" = "application/json";
+                };
+                data = "$NEW_CONFIG";
+                extraArgs = "-f";
+              }
+            } > /dev/null
+
+            echo "Configuration updated successfully"
+
+            echo "Restarting ${serviceName} service..."
+            systemctl restart ${serviceName}.service
+            echo "${capitalizedName} service restarted"
+          '';
+        };
+    })
   ];
 }

--- a/modules/seerr/sonarr/default.nix
+++ b/modules/seerr/sonarr/default.nix
@@ -211,18 +211,16 @@ in
     systemd.services.seerr-sonarr = {
       description = "Configure Seerr Sonarr integration";
       after = [
-        "seerr-radarr.service"
+        "seerr-libraries.service"
       ]
-      ++ optional (cfg.radarr != { }) "seerr-radarr.service"
       ++ optional nixflix.sonarr.enable "sonarr-config.service"
-      ++ optional (nixflix.sonarr-anime.enable or false) "sonarr-anime-config.service";
+      ++ optional nixflix.sonarr-anime.enable "sonarr-anime-config.service";
 
       requires = [
-        "seerr-radarr.service"
+        "seerr-libraries.service"
       ]
-      ++ optional (cfg.radarr != { }) "seerr-radarr.service"
       ++ optional nixflix.sonarr.enable "sonarr-config.service"
-      ++ optional (nixflix.sonarr-anime.enable or false) "sonarr-anime-config.service";
+      ++ optional nixflix.sonarr-anime.enable "sonarr-anime-config.service";
 
       wantedBy = [ "multi-user.target" ];
 


### PR DESCRIPTION
- `*arr-config` services did not get created at all if both `username` and `password` were set to `null` despite being told it was a valid configuration.
  https://github.com/kiriwalawren/nixflix/blob/7880f3ec5bfc5145d56936b4f48d58cf23c1cc4b/modules/arr-common/hostConfig.nix#L271
  This leads to a wide variety of hard to diagnose bugs meaning that most options configured in nixflix weren't set and that no integration between services was working.
- seer's sonarr configuration service erroneously required `seerr-radarr` meaning that it will fail if the user only has sonarr without radarr. I changed it to require `seerr-libraries` as the `seer-radarr` service does