### PR TITLE
use Jellyfin-Server user agent when fetching plugin repository manifest

### DIFF
--- a/modules/jellyfin/plugins/resolvePlugins.nix
+++ b/modules/jellyfin/plugins/resolvePlugins.nix
@@ -46,8 +46,9 @@ let
     // {
       manifest = builtins.fromJSON (
         builtins.readFile (
-          builtins.fetchurl {
+          pkgs.fetchurl {
             inherit (repo) url;
+            curlOptsList = ["-A" "Jellyfin-Server/${jellyfinVersion} (Nixflix plugin repository resolver)" "-L"];
             sha256 =
               let
                 inherit (repo) hash;


### PR DESCRIPTION
This makes manifest URLs which depend on the user-agent work, like for [Intro-skipper](https://github.com/intro-skipper/server_configs/blob/21fafb8b292ef2585687fe916de55694a71000e6/docker/Caddyfile#L32-L37), https://intro-skipper.org/manifest.json
