### PR TITLE
Adjust radarr min_format_score to 180 for better media acquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Radarr's default Recyclarr quality profile now sets `min_format_score` to `180` instead of `1000`, to prefer media acquisition ([#305](https://github.com/kiriwalawren/nixflix/issues/305))
+
 ### Added
 
 - Notif Service for configuring notification connectors in Starr apps ([#324](https://github.com/kiriwalawren/nixflix/pull/324))

--- a/modules/recyclarr/radarr.nix
+++ b/modules/recyclarr/radarr.nix
@@ -27,6 +27,9 @@ in
           else
             "0896c29d74de619df168d23b98104b22"; # [SQP] SQP-1 (1080p)
         reset_unmatched_scores.enabled = true;
+
+        # Lower minimal score to allow better media acquisition
+        min_format_score = 180;
       }
     ];
   };

--- a/tests/vm-tests/recyclarr-basic.nix
+++ b/tests/vm-tests/recyclarr-basic.nix
@@ -164,6 +164,12 @@ pkgsUnfree.testers.runNixOSTest {
     assert radarr_profile_names == {"[SQP] SQP-1 (1080p)"}, \
         f"Expected only '[SQP] SQP-1 (1080p)' in Radarr after cleanup, found: {radarr_profile_names}"
 
+    # The guide ships SQP-1 with a minimum score of 1000, which is adjusted
+    # by default to lower value in order to improve media acquisition
+    radarr_min_format_score = radarr_profiles_list[0]['minFormatScore']
+    assert radarr_min_format_score == 180, \
+        f"Expected Radarr minFormatScore of 180, found: {radarr_min_format_score}"
+
     # Check that quality profiles were created by recyclarr for Sonarr
     sonarr_profiles = machine.succeed(
         "curl -s -H 'X-Api-Key: efgh5678efgh5678efgh5678efgh5678' "


### PR DESCRIPTION
Fixes https://github.com/kiriwalawren/nixflix/issues/305 by adjusting minFormatScore to lower value for better media acquisition.